### PR TITLE
fix: prevent crash when exercise lookup is undefined

### DIFF
--- a/apps/mobile/src/pages/ActiveWorkout.tsx
+++ b/apps/mobile/src/pages/ActiveWorkout.tsx
@@ -1852,45 +1852,48 @@ export default function ActiveWorkout() {
             </div>
           </div>
           <div className="flex flex-col gap-3">
-            {items.map((item) =>
-              item.kind === "solo" ? (
-                <ActiveExerciseCard
-                  key={item.exerciseId}
-                  exercise={exerciseLookup[item.exerciseId]!}
-                  data={exData[item.exerciseId]}
-                  unit={unit}
-                  onUpdate={(d) => updateExData(item.exerciseId, d)}
-                  onRemove={() => removeExercise(item.exerciseId)}
-                  isDragging={drag?.exerciseId === item.exerciseId && drag.active}
-                  {...cardProps(item.exerciseId)}
-                  collapsed={Boolean(collapsed[item.exerciseId])}
-                  onToggleCollapse={() => toggleCollapsed(item.exerciseId)}
-                  dragHandlers={makeDragHandlers(item.exerciseId)}
-                  cardRef={(el) => {
-                    if (el) cardRefs.current.set(item.exerciseId, el)
-                    else cardRefs.current.delete(item.exerciseId)
-                  }}
-                  onStartRest={rest.start}
-                />
-              ) : (
-                renderSupersetItem(
-                    item,
-                    exData,
-                    unit,
-                    updateExData,
-                    removeExercise,
-                    drag,
-                    dropTarget,
-                    collapsed,
-                    toggleCollapsed,
-                    makeDragHandlers,
-                    cardRefs,
-                    rest.start,
-                    cardProps,
-                    exerciseLookup
+            {items.map((item) => {
+              if (item.kind === "solo") {
+                const ex = exerciseLookup[item.exerciseId]
+                if (!ex) return null
+                return (
+                  <ActiveExerciseCard
+                    key={item.exerciseId}
+                    exercise={ex}
+                    data={exData[item.exerciseId]}
+                    unit={unit}
+                    onUpdate={(d) => updateExData(item.exerciseId, d)}
+                    onRemove={() => removeExercise(item.exerciseId)}
+                    isDragging={drag?.exerciseId === item.exerciseId && drag.active}
+                    {...cardProps(item.exerciseId)}
+                    collapsed={Boolean(collapsed[item.exerciseId])}
+                    onToggleCollapse={() => toggleCollapsed(item.exerciseId)}
+                    dragHandlers={makeDragHandlers(item.exerciseId)}
+                    cardRef={(el) => {
+                      if (el) cardRefs.current.set(item.exerciseId, el)
+                      else cardRefs.current.delete(item.exerciseId)
+                    }}
+                    onStartRest={rest.start}
+                  />
                 )
+              }
+              return renderSupersetItem(
+                item,
+                exData,
+                unit,
+                updateExData,
+                removeExercise,
+                drag,
+                dropTarget,
+                collapsed,
+                toggleCollapsed,
+                makeDragHandlers,
+                cardRefs,
+                rest.start,
+                cardProps,
+                exerciseLookup
               )
-            )}
+            })}
           </div>
           <button
             onClick={() => setSearchOpen(true)}


### PR DESCRIPTION
Add defensive null check for solo exercise items in ActiveWorkout. Previously, if exerciseLookup[item.exerciseId] was undefined (due to async loading not yet complete or invalid exercise IDs in presets), the component would crash with 'cannot access property color'. Now returns null instead of rendering the component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved reliability of solo exercise rendering during active workouts with enhanced handling of missing exercise data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->