### PR TITLE
fix: add confirmation modal for deleting workout

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -1218,6 +1218,7 @@ export default function App() {
   const clearOnboarding = useMutation(api.users.onboarding.clear)
   const setDashboardSettings = useMutation(api.users.users.setDashboardSettings)
   const setDay = useMutation(api.logs.foodLogs.setDay)
+  const removeWorkoutBySlot = useMutation(api.logs.workouts.removeBySlot)
 
   // ── Dashboard settings ───────────────────────────────────────────────────
 
@@ -1285,7 +1286,7 @@ export default function App() {
   }, [activeTimezone, selectedDate, storedPresets, storedRoutine])
 
   const [todayWorkoutCollapsed, setTodayWorkoutCollapsed] = useState(false)
-  const [, setConfirmDeleteSlot] = useState<1 | 2 | null>(null)
+  const [confirmDeleteSlot, setConfirmDeleteSlot] = useState<1 | 2 | null>(null)
   const [homeAddOpen, setHomeAddOpen] = useState(false)
   const [snapOffline, setSnapOffline] = useState(false)
 
@@ -1489,6 +1490,49 @@ export default function App() {
             </div>
           )}
         </MobileSheet>
+      )}
+
+      {confirmDeleteSlot && (
+        <div
+          className="sheet-overlay fixed inset-0 z-50 flex items-end justify-center bg-black/50 backdrop-blur-[3px]"
+          onClick={() => setConfirmDeleteSlot(null)}
+        >
+          <div
+            className="sheet-panel w-full max-w-sm overflow-hidden rounded-t-3xl bg-card shadow-2xl"
+            style={{
+              paddingBottom: "max(2rem, env(safe-area-inset-bottom, 2rem))",
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mx-auto mt-3 mb-5 h-1 w-10 rounded-full bg-border/60" />
+            <div className="px-6">
+              <h2 className="text-[17px] font-bold tracking-tight">
+                Delete workout?
+              </h2>
+              <p className="mt-1.5 text-[13px] leading-relaxed text-muted-foreground/70">
+                This will remove the workout from your log. This cannot be undone.
+              </p>
+              <div className="mt-6 flex flex-col gap-2">
+                <button
+                  onClick={() => {
+                    void removeWorkoutBySlot({ date: selectedDate, slot: confirmDeleteSlot })
+                    setConfirmDeleteSlot(null)
+                  }}
+                  className="h-12 w-full rounded-xl bg-red-500/90 text-[14px] font-bold text-white transition-opacity active:opacity-80"
+                >
+                  Delete
+                </button>
+                <button
+                  onClick={() => setConfirmDeleteSlot(null)}
+                  className="h-12 w-full rounded-xl bg-muted text-[14px] font-bold text-foreground transition-opacity active:opacity-80"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+            <div className="h-4" />
+          </div>
+        </div>
       )}
     </div>
   )

--- a/convex/logs/workouts.ts
+++ b/convex/logs/workouts.ts
@@ -86,3 +86,26 @@ export const remove = mutation({
     await ctx.db.delete(id);
   },
 });
+
+// ── removeBySlot ────────────────────────────────────────────────────────────────
+
+export const removeBySlot = mutation({
+  args: { date: v.string(), slot: v.number() },
+  handler: async (ctx, { date, slot }) => {
+    const user = await authComponent.getAuthUser(ctx);
+    if (!user) throw new Error("Not authenticated");
+
+    const logs = await ctx.db
+      .query("workoutLogs")
+      .withIndex("by_userId_date", (q) =>
+        q.eq("userId", user._id).eq("date", date),
+      )
+      .collect();
+
+    if (slot === 1 && logs[0]) {
+      await ctx.db.delete(logs[0]._id);
+    } else if (slot === 2 && logs[1]) {
+      await ctx.db.delete(logs[1]._id);
+    }
+  },
+});

--- a/convex/logs/workouts.ts
+++ b/convex/logs/workouts.ts
@@ -90,7 +90,8 @@ export const remove = mutation({
 // ── removeBySlot ────────────────────────────────────────────────────────────────
 
 export const removeBySlot = mutation({
-  args: { date: v.string(), slot: v.number() },
+export const removeBySlot = mutation({
+  args: { date: v.string(), slot: v.union(v.literal(1), v.literal(2)) },
   handler: async (ctx, { date, slot }) => {
     const user = await authComponent.getAuthUser(ctx);
     if (!user) throw new Error("Not authenticated");
@@ -102,10 +103,11 @@ export const removeBySlot = mutation({
       )
       .collect();
 
-    if (slot === 1 && logs[0]) {
-      await ctx.db.delete(logs[0]._id);
-    } else if (slot === 2 && logs[1]) {
-      await ctx.db.delete(logs[1]._id);
-    }
+    const target = logs[slot - 1];
+    if (!target) throw new Error("Workout slot not found");
+    await ctx.db.delete(target._id);
+    return { ok: true };
+  },
+});
   },
 });


### PR DESCRIPTION
Add removeBySlot mutation to allow deleting a workout log by date and slot. Add confirmation modal UI with Delete/Cancel buttons to prevent accidental deletion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now delete an individual workout by choosing its date and time slot. A confirmation overlay appears (click outside to dismiss); "Delete" removes the selected workout and closes the overlay, while "Cancel" simply closes it. This adds a clear, reversible step to prevent accidental deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->