### PR TITLE
🛡️ Sentinel: Consolidate DB pool and move initialization to startup

### DIFF
--- a/apps/data-api/app.ts
+++ b/apps/data-api/app.ts
@@ -1,6 +1,5 @@
 require("dotenv").config({ path: require("path").join(__dirname, "../.env") });
 
-import { sql } from "drizzle-orm";
 import express from "express";
 import cookieParser from "cookie-parser";
 import logger from "morgan";
@@ -11,12 +10,9 @@ import indexRouter from "./routes/index";
 
 const app = express();
 
-// Test PostgreSQL connection on startup
-import { db } from "./src/db/index";
-
-db.execute(sql`SELECT 1`)
-  .then(() => console.log("[INFO] PostgreSQL connected"))
-  .catch((err: Error) => console.error("[WARN] PostgreSQL connection failed:", err.message));
+// Initialize database on startup
+import { initDb } from "./src/db/index";
+initDb();
 
 app.use(helmet());
 app.use(logger("dev"));

--- a/apps/data-api/routes/api.ts
+++ b/apps/data-api/routes/api.ts
@@ -1,17 +1,9 @@
 import express, { Request, Response, type Router } from "express";
-import pg from "pg";
+import { pool } from "../src/db/index";
 import { apiLimiter, searchLimiter, strictLimiter } from "../middleware/rateLimit";
 import { searchQuerySchema, barcodeSchema, idParamSchema } from "../lib/validation";
 
 const router: Router = express.Router();
-
-if (!process.env.DATABASE_URL) {
-  throw new Error("DATABASE_URL environment variable is required");
-}
-
-const pool = new pg.Pool({
-  connectionString: process.env.DATABASE_URL,
-});
 
 /**
  * Execute a SQL query against the module's PostgreSQL pool and return the resulting rows.
@@ -43,11 +35,6 @@ router.get("/foods/search", async (req: Request, res: Response) => {
   const q = req.query.q as string || "";
   const limit = Math.min(Number(req.query.limit) || 25, 50);
   try {
-    // Enable pg_trgm extension and create GIN indexes on first run
-    await query("CREATE EXTENSION IF NOT EXISTS pg_trgm");
-    await query("CREATE INDEX CONCURRENTLY IF NOT EXISTS foodfacts_name_trgm_idx ON foodfacts USING gin (name gin_trgm_ops)");
-    await query("CREATE INDEX CONCURRENTLY IF NOT EXISTS foodfacts_brand_trgm_idx ON foodfacts USING gin (brand gin_trgm_ops)");
-
     const results = await query(
       "SELECT * FROM foodfacts WHERE name ILIKE $1 OR brand ILIKE $1 LIMIT $2",
       [`%${q}%`, limit]

--- a/apps/data-api/routes/index.ts
+++ b/apps/data-api/routes/index.ts
@@ -1,15 +1,7 @@
 import { Router, Request, Response } from "express";
-import pg from "pg";
+import { pool } from "../src/db/index";
 
 const router: Router = Router();
-
-if (!process.env.DATABASE_URL) {
-  throw new Error("DATABASE_URL environment variable is required");
-}
-
-const pool = new pg.Pool({
-  connectionString: process.env.DATABASE_URL,
-});
 
 router.get("/", async (_req: Request, res: Response) => {
   try {

--- a/apps/data-api/src/db/index.ts
+++ b/apps/data-api/src/db/index.ts
@@ -7,10 +7,29 @@ if (!process.env.DATABASE_URL) {
   throw new Error("DATABASE_URL environment variable is required");
 }
 
-const pool = new pg.Pool({
+export const pool = new pg.Pool({
   connectionString: process.env.DATABASE_URL,
 });
 
 export const db = drizzle(pool);
+
+export async function initDb() {
+  const client = await pool.connect();
+  try {
+    console.log("[INFO] Initializing database...");
+    await client.query("CREATE EXTENSION IF NOT EXISTS pg_trgm");
+    // CREATE INDEX CONCURRENTLY cannot be run inside a transaction block.
+    // pool.query might use a single statement or transaction depending on configuration,
+    // but a fresh client connection is the most reliable way to ensure we're not in a transaction.
+    await client.query("CREATE INDEX CONCURRENTLY IF NOT EXISTS foodfacts_name_trgm_idx ON foodfacts USING gin (name gin_trgm_ops)");
+    await client.query("CREATE INDEX CONCURRENTLY IF NOT EXISTS foodfacts_brand_trgm_idx ON foodfacts USING gin (brand gin_trgm_ops)");
+    console.log("[INFO] Database initialization complete");
+  } catch (err) {
+    console.error("[ERR] Database initialization failed:", err);
+  } finally {
+    client.release();
+  }
+}
+
 export { foodfacts, exercises };
 export type DB = typeof db;


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Consolidate DB pool and move initialization to startup

### 🚨 Severity: MEDIUM

### 💡 Vulnerability
The application was creating multiple database connection pools across different route files and executing database initialization logic (creating extensions and indexes) within a high-traffic GET request handler (`/foods/search`).

### 🎯 Impact
1. **Resource Exhaustion:** Multiple pools could quickly exhaust available database connections, leading to service downtime.
2. **DoS Risk:** Executing DDL commands (`CREATE INDEX`) inside request handlers is extremely inefficient and introduces lock contention risks, which could be exploited to cause a Denial of Service.

### 🔧 Fix
- Exported a single `pg.Pool` instance from `apps/data-api/src/db/index.ts`.
- Implemented `initDb` to handle database schema readiness (extensions and indexes) on startup.
- Updated all routes to use the shared pool.
- Removed redundant initialization logic from the request path.

### ✅ Verification
- Verified code changes and ran `tsc` for type-safety.
- Ran Convex test suite with all tests passing.
- Confirmed database initialization is triggered on startup in `app.ts`.

---
*PR created automatically by Jules for task [12941021738526558225](https://jules.google.com/task/12941021738526558225) started by @an2tha*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized database connection management across API routes
  * Database initialization moved to application startup phase
  * Search indexes are now created at startup instead of on first request, improving response times

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/an2tha/onerep/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->