### PR TITLE
Harden Better Auth session cleanup and auth checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ VITE_APP_URL=https://app.onerep.life
 VITE_SITE_URL=https://onerep.life
 
 # Auth / analytics
+BETTER_AUTH_SECRET=
 VITE_PUBLIC_POSTHOG_PROJECT_TOKEN=
 VITE_PUBLIC_POSTHOG_HOST=
 RESEND_API_KEY=

--- a/README.md
+++ b/README.md
@@ -101,11 +101,12 @@ VITE_CONVEX_SITE_URL=
 Required for mobile food search in Convex env:
 
 ```env
+BETTER_AUTH_SECRET=
 OPENFOODFACTS_URL=https://world.openfoodfacts.org
 OPENFOODFACTS_AUTH_TOKEN=
 ```
 
-Set these with `bunx convex env set OPENFOODFACTS_URL <url>` and, for the auth-protected mirror, `bunx convex env set OPENFOODFACTS_AUTH_TOKEN <token>`. The mobile app talks only to Convex.
+Generate `BETTER_AUTH_SECRET` with `openssl rand -base64 32`. Set these with `bunx convex env set BETTER_AUTH_SECRET <secret>`, `bunx convex env set OPENFOODFACTS_URL <url>`, and, for the auth-protected mirror, `bunx convex env set OPENFOODFACTS_AUTH_TOKEN <token>`. The mobile app talks only to Convex.
 
 Food search and barcode lookups use Open Food Facts Product Opener-compatible endpoints (`/cgi/search.pl` and `/api/v2/product/:code.json`) through a Convex proxy. `docker-compose.dev-requirements.yml` starts a local Product Opener mirror from published GHCR images, no Open Food Facts repo clone required. The upstream Product Opener images are currently amd64-only, so the compose file defaults `OFF_PLATFORM=linux/amd64` for Apple Silicon Docker emulation; first startup can take a minute while Apache warms up. `bun run docker:dev:reqs:seed` imports a small sample set only, so arbitrary public barcodes may return 404 until you import fuller OFF data.
 

--- a/apps/mobile/src/components/auth-guard.tsx
+++ b/apps/mobile/src/components/auth-guard.tsx
@@ -1,18 +1,29 @@
 import { useEffect } from "react"
 import { authClient } from "@/lib/auth-client"
+import { handleUnauthenticatedSession } from "@/lib/auth-session"
 import { useSmoothNavigate } from "@/lib/navigation"
+import { useConvexAuth } from "convex/react"
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {
   const { data: session, isPending } = authClient.useSession()
+  const convexAuth = useConvexAuth()
   const navigate = useSmoothNavigate()
 
   useEffect(() => {
-    if (!isPending && !session) {
-      navigate("/login", { replace: true })
-    }
-  }, [session, isPending, navigate])
+    if (isPending || convexAuth.isLoading) return
 
-  if (isPending) {
+    if (!session || !convexAuth.isAuthenticated) {
+      handleUnauthenticatedSession({ navigate })
+    }
+  }, [
+    session,
+    isPending,
+    convexAuth.isLoading,
+    convexAuth.isAuthenticated,
+    navigate,
+  ])
+
+  if (isPending || convexAuth.isLoading) {
     return (
       <div className="flex min-h-svh items-center justify-center">
         <div className="h-5 w-5 animate-spin rounded-full border-2 border-foreground/20 border-t-foreground" />
@@ -20,7 +31,7 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
     )
   }
 
-  if (!session) return null
+  if (!session || !convexAuth.isAuthenticated) return null
 
   return <>{children}</>
 }

--- a/apps/mobile/src/components/error-boundary.tsx
+++ b/apps/mobile/src/components/error-boundary.tsx
@@ -1,5 +1,9 @@
 import { Component, type ErrorInfo, type ReactNode } from "react"
 import { ArrowCounterClockwise, Warning } from "@phosphor-icons/react"
+import {
+  handleUnauthenticatedSession,
+  isUnauthenticatedError,
+} from "@/lib/auth-session"
 
 interface Props {
   children: ReactNode
@@ -20,12 +24,23 @@ export class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error("[ErrorBoundary]", error, info.componentStack)
+    if (isUnauthenticatedError(error)) {
+      handleUnauthenticatedSession()
+    }
   }
 
   reset = () => this.setState({ error: null })
 
   render() {
     if (!this.state.error) return this.props.children
+
+    if (isUnauthenticatedError(this.state.error)) {
+      return (
+        <div className="flex min-h-svh items-center justify-center">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-foreground/20 border-t-foreground" />
+        </div>
+      )
+    }
 
     const label = this.props.label ?? "this page"
 

--- a/apps/mobile/src/components/offline-sync-indicator.tsx
+++ b/apps/mobile/src/components/offline-sync-indicator.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react"
 import { CloudArrowUp, WifiSlash, X } from "@phosphor-icons/react"
+import { useConvexAuth } from "convex/react"
 import { authClient } from "@/lib/auth-client"
 import {
   flushOfflineQueue,
@@ -16,9 +17,11 @@ function onlineNow() {
 
 export function OfflineSyncIndicator() {
   const { data: session } = authClient.useSession()
+  const convexAuth = useConvexAuth()
   const [online, setOnline] = useState(onlineNow())
   const [summary, setSummary] = useState(getOfflineQueueSummary())
   const [dismissed, setDismissed] = useState(false)
+  const canSync = online && Boolean(session) && convexAuth.isAuthenticated
 
   useEffect(() => {
     setOfflineQueueOwner(session?.user?.id ?? null)
@@ -32,7 +35,9 @@ export function OfflineSyncIndicator() {
 
     const tryFlush = () => {
       refresh()
-      void flushOfflineQueue().then(refresh)
+      if (canSync) {
+        void flushOfflineQueue().then(refresh)
+      }
     }
 
     const unsubscribe = subscribeOfflineQueue(refresh)
@@ -47,7 +52,7 @@ export function OfflineSyncIndicator() {
       window.removeEventListener("offline", refresh)
       window.removeEventListener("focus", tryFlush)
     }
-  }, [])
+  }, [canSync])
 
   useEffect(() => {
     if (!online || summary.total > 0) setDismissed(false)
@@ -55,7 +60,7 @@ export function OfflineSyncIndicator() {
 
   if (dismissed || (online && summary.total === 0)) return null
 
-  const syncing = online && summary.total > 0
+  const syncing = canSync && summary.total > 0
 
   return (
     <div className="pointer-events-none fixed inset-x-0 top-[calc(env(safe-area-inset-top)+10px)] z-[10000] flex justify-center px-4">
@@ -64,15 +69,21 @@ export function OfflineSyncIndicator() {
           "pointer-events-auto flex max-w-sm items-center gap-3 rounded-full border px-3 py-2 shadow-xl backdrop-blur-md",
           online
             ? "border-amber-400/30 bg-amber-50/95 text-amber-950 dark:bg-amber-950/90 dark:text-amber-50"
-            : "border-border/50 bg-card/95 text-foreground",
+            : "border-border/50 bg-card/95 text-foreground"
         )}
       >
         <div className="flex h-7 w-7 items-center justify-center rounded-full bg-foreground/10">
-          {online ? <CloudArrowUp size={15} weight="bold" /> : <WifiSlash size={15} weight="bold" />}
+          {online ? (
+            <CloudArrowUp size={15} weight="bold" />
+          ) : (
+            <WifiSlash size={15} weight="bold" />
+          )}
         </div>
         <div className="min-w-0 flex-1">
-          <p className="text-[12px] font-bold leading-tight">
-            {syncing ? `${summary.total} change${summary.total === 1 ? "" : "s"} waiting to sync` : "Offline mode"}
+          <p className="text-[12px] leading-tight font-bold">
+            {syncing
+              ? `${summary.total} change${summary.total === 1 ? "" : "s"} waiting to sync`
+              : "Offline mode"}
           </p>
           <p className="truncate text-[10.5px] opacity-65">
             {syncing
@@ -80,10 +91,14 @@ export function OfflineSyncIndicator() {
               : "Keep logging. Changes are saved locally."}
           </p>
         </div>
-        {online && summary.total > 0 && (
+        {canSync && summary.total > 0 && (
           <button
             type="button"
-            onClick={() => void flushOfflineQueue().then(() => setSummary(getOfflineQueueSummary()))}
+            onClick={() =>
+              void flushOfflineQueue().then(() =>
+                setSummary(getOfflineQueueSummary())
+              )
+            }
             className="rounded-full bg-foreground px-2.5 py-1 text-[10px] font-bold text-background"
           >
             Sync

--- a/apps/mobile/src/lib/__tests__/auth-session.test.ts
+++ b/apps/mobile/src/lib/__tests__/auth-session.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+import {
+  clearLocalStorageCache,
+  clearUnauthenticatedLocalState,
+  isUnauthenticatedError,
+} from "../auth-session"
+
+class MemoryStorage {
+  private values = new Map<string, string>()
+
+  get length() {
+    return this.values.size
+  }
+
+  key(index: number) {
+    return Array.from(this.values.keys())[index] ?? null
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value)
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key)
+  }
+
+  clear() {
+    this.values.clear()
+  }
+}
+
+function installStorage() {
+  const storage = new MemoryStorage()
+  Object.defineProperty(globalThis, "localStorage", {
+    value: storage,
+    configurable: true,
+  })
+  Object.defineProperty(globalThis, "window", {
+    value: { localStorage: storage, location: { pathname: "/" } },
+    configurable: true,
+  })
+  return storage
+}
+
+describe("auth session helpers", () => {
+  beforeEach(() => {
+    installStorage()
+  })
+
+  test("detects Convex unauthenticated errors", () => {
+    expect(isUnauthenticatedError(new Error("Unauthenticated"))).toBe(true)
+    expect(isUnauthenticatedError(new Error("Network error"))).toBe(false)
+  })
+
+  test("clears app-owned local storage keys only", () => {
+    localStorage.setItem("onerep:offline-mutation-queue:v1", "[]")
+    localStorage.setItem("onerep_custom_meal_categories", "[]")
+    localStorage.setItem("better-auth.session", "token")
+    localStorage.setItem("convex:auth", "token")
+    localStorage.setItem("theme", "dark")
+    localStorage.setItem("external:keep", "value")
+
+    clearLocalStorageCache()
+
+    expect(localStorage.getItem("onerep:offline-mutation-queue:v1")).toBeNull()
+    expect(localStorage.getItem("onerep_custom_meal_categories")).toBeNull()
+    expect(localStorage.getItem("better-auth.session")).toBeNull()
+    expect(localStorage.getItem("convex:auth")).toBeNull()
+    expect(localStorage.getItem("theme")).toBeNull()
+    expect(localStorage.getItem("external:keep")).toBe("value")
+  })
+
+  test("marks intro as seen after unauthenticated cleanup", () => {
+    localStorage.setItem("onerep:offline-owner:v1", "user")
+
+    clearUnauthenticatedLocalState()
+
+    expect(localStorage.getItem("onerep:offline-owner:v1")).toBeNull()
+    expect(localStorage.getItem("onerep:prelogin-onboarding-seen")).toBe("true")
+  })
+})

--- a/apps/mobile/src/lib/auth-session.ts
+++ b/apps/mobile/src/lib/auth-session.ts
@@ -1,0 +1,86 @@
+import type { NavigateOptions, To } from "react-router"
+
+type Navigate = (to: To, options?: NavigateOptions) => void | Promise<void>
+
+const LOGIN_PATH = "/login"
+const PRELOGIN_SEEN_KEY = "onerep:prelogin-onboarding-seen"
+const LOCAL_STORAGE_PREFIXES_TO_CLEAR = [
+  "onerep:",
+  "onerep_",
+  "better-auth",
+  "convex:",
+]
+const LOCAL_STORAGE_KEYS_TO_CLEAR = new Set(["theme"])
+
+let authRedirectInFlight = false
+
+function hasStorage() {
+  return typeof window !== "undefined" && typeof localStorage !== "undefined"
+}
+
+function getErrorText(error: unknown) {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`
+  }
+  if (typeof error === "object" && error !== null && "message" in error) {
+    return String((error as { message?: unknown }).message)
+  }
+  return String(error)
+}
+
+export function isUnauthenticatedError(error: unknown) {
+  const text = getErrorText(error)
+  return /\bUnauthenticated\b/i.test(text)
+}
+
+export function clearLocalStorageCache() {
+  if (!hasStorage()) return
+
+  const keys: string[] = []
+  for (let index = 0; index < localStorage.length; index += 1) {
+    const key = localStorage.key(index)
+    if (key) keys.push(key)
+  }
+
+  for (const key of keys) {
+    if (
+      LOCAL_STORAGE_KEYS_TO_CLEAR.has(key) ||
+      LOCAL_STORAGE_PREFIXES_TO_CLEAR.some((prefix) => key.startsWith(prefix))
+    ) {
+      localStorage.removeItem(key)
+    }
+  }
+}
+
+export function clearUnauthenticatedLocalState() {
+  clearLocalStorageCache()
+
+  if (!hasStorage()) return
+  localStorage.setItem(PRELOGIN_SEEN_KEY, "true")
+}
+
+function redirectToLogin(navigate?: Navigate) {
+  if (navigate) {
+    void navigate(LOGIN_PATH, { replace: true })
+    return
+  }
+
+  if (typeof window === "undefined") return
+  if (window.location.pathname === LOGIN_PATH) return
+
+  window.location.replace(LOGIN_PATH)
+}
+
+export function handleUnauthenticatedSession(options?: {
+  navigate?: Navigate
+}) {
+  if (authRedirectInFlight) return
+  authRedirectInFlight = true
+
+  clearUnauthenticatedLocalState()
+
+  void import("@/lib/auth-client")
+    .then(({ authClient }) => authClient.signOut())
+    .catch(() => undefined)
+    .finally(() => redirectToLogin(options?.navigate))
+}

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -11,7 +11,6 @@ import { createBrowserRouter, Outlet, useLocation } from "react-router"
 import { RouterProvider } from "react-router/dom"
 import posthog from "posthog-js"
 import { PostHogProvider } from "@posthog/react"
-import { ConvexProvider } from "convex/react"
 import {
   ConvexBetterAuthProvider,
   type AuthClient,
@@ -355,21 +354,19 @@ const router = createBrowserRouter([
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <ConvexProvider client={convexClient}>
-      <ConvexBetterAuthProvider
-        client={convexClient}
-        authClient={authClient as unknown as AuthClient}
-      >
-        <PostHogProvider client={posthog}>
-          <ThemeProvider>
-            <ErrorBoundary label="the app">
-              <OfflineSyncIndicator />
-              <RouterProvider router={router} />
-              <Toaster position="top-center" richColors />
-            </ErrorBoundary>
-          </ThemeProvider>
-        </PostHogProvider>
-      </ConvexBetterAuthProvider>
-    </ConvexProvider>
+    <ConvexBetterAuthProvider
+      client={convexClient}
+      authClient={authClient as unknown as AuthClient}
+    >
+      <PostHogProvider client={posthog}>
+        <ThemeProvider>
+          <ErrorBoundary label="the app">
+            <OfflineSyncIndicator />
+            <RouterProvider router={router} />
+            <Toaster position="top-center" richColors />
+          </ErrorBoundary>
+        </ThemeProvider>
+      </PostHogProvider>
+    </ConvexBetterAuthProvider>
   </StrictMode>
 )

--- a/convex/__tests__/authz.convex.test.ts
+++ b/convex/__tests__/authz.convex.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, test } from "vitest";
+import { convexTest } from "convex-test";
+import schema from "../schema";
+import { api } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.ts");
+
+const reminder = { enabled: true, hour: 8, minute: 0 };
+const presetBody = {
+  name: "Protected preset",
+  items: [],
+  exerciseData: {},
+};
+const recipeIngredient = {
+  id: "ingredient-1",
+  name: "Chicken breast",
+  grams: 100,
+  caloriesPer100: 165,
+  proteinPer100: 31,
+  carbsPer100: 0,
+  fatPer100: 3.6,
+};
+const healthProfile = {
+  sex: "male",
+  age: 30,
+  weightKg: 80,
+  heightCm: 180,
+  activityLevel: "moderately_active",
+  goal: "maintain",
+} as const;
+const workoutExercise = {
+  id: "squat",
+  name: "Squat",
+  sets: [{ type: "normal", reps: 5, weight: 100, completed: true }],
+};
+const fakeId = "jd7f4z1y2s3d4t5v6w7x8" as any;
+
+type PublicWriteCase = {
+  name: string;
+  kind: "mutation" | "action";
+  fn: any;
+  args: Record<string, unknown>;
+};
+
+const unauthenticatedWriteCases: PublicWriteCase[] = [
+  {
+    name: "bodyProgress.generateUploadUrl",
+    kind: "mutation",
+    fn: api.bodyProgress.generateUploadUrl,
+    args: {},
+  },
+  {
+    name: "bodyProgress.save",
+    kind: "mutation",
+    fn: api.bodyProgress.save,
+    args: { clientId: "body-1", loggedAt: "2026-06-25" },
+  },
+  {
+    name: "bodyProgress.remove",
+    kind: "mutation",
+    fn: api.bodyProgress.remove,
+    args: { clientId: "body-1" },
+  },
+  {
+    name: "users.checkIn.setDailyCheckIn",
+    kind: "mutation",
+    fn: api.users.checkIn.setDailyCheckIn,
+    args: {},
+  },
+  {
+    name: "users.users.syncTimezone",
+    kind: "mutation",
+    fn: api.users.users.syncTimezone,
+    args: { timeZone: "America/New_York" },
+  },
+  {
+    name: "users.users.setBodyReminder",
+    kind: "mutation",
+    fn: api.users.users.setBodyReminder,
+    args: reminder,
+  },
+  {
+    name: "users.users.setCustomMealCategories",
+    kind: "mutation",
+    fn: api.users.users.setCustomMealCategories,
+    args: { categories: [] },
+  },
+  {
+    name: "users.users.setDashboardSettings",
+    kind: "mutation",
+    fn: api.users.users.setDashboardSettings,
+    args: { workoutFocus: "strength" },
+  },
+  {
+    name: "users.users.setWeightUnit",
+    kind: "mutation",
+    fn: api.users.users.setWeightUnit,
+    args: { unit: "kg" },
+  },
+  {
+    name: "users.users.setWaterGoal",
+    kind: "mutation",
+    fn: api.users.users.setWaterGoal,
+    args: { goalMl: 2000 },
+  },
+  {
+    name: "users.users.setWidgetLayout",
+    kind: "mutation",
+    fn: api.users.users.setWidgetLayout,
+    args: { layout: [] },
+  },
+  {
+    name: "users.users.setCustomGoals",
+    kind: "mutation",
+    fn: api.users.users.setCustomGoals,
+    args: { calories: 2000 },
+  },
+  {
+    name: "users.users.setMacroCycling",
+    kind: "mutation",
+    fn: api.users.users.setMacroCycling,
+    args: { enabled: false },
+  },
+  {
+    name: "users.users.setWorkoutAdjustment",
+    kind: "mutation",
+    fn: api.users.users.setWorkoutAdjustment,
+    args: { enabled: true },
+  },
+  {
+    name: "users.users.setPushReminders",
+    kind: "mutation",
+    fn: api.users.users.setPushReminders,
+    args: {
+      reminders: {
+        water: reminder,
+        meal: reminder,
+        workout: reminder,
+        body: reminder,
+      },
+    },
+  },
+  {
+    name: "users.users.setPrivacySettings",
+    kind: "mutation",
+    fn: api.users.users.setPrivacySettings,
+    args: {
+      analyticsEnabled: false,
+      personalizedInsightsEnabled: false,
+    },
+  },
+  {
+    name: "users.users.deleteMyDataBatch",
+    kind: "mutation",
+    fn: api.users.users.deleteMyDataBatch,
+    args: {},
+  },
+  {
+    name: "users.onboarding.save",
+    kind: "mutation",
+    fn: api.users.onboarding.save,
+    args: { age: 30, heightCm: 180, goal: "health" },
+  },
+  {
+    name: "users.onboarding.clear",
+    kind: "mutation",
+    fn: api.users.onboarding.clear,
+    args: {},
+  },
+  {
+    name: "users.schedules.set",
+    kind: "mutation",
+    fn: api.users.schedules.set,
+    args: { routine: {}, presetOrder: [] },
+  },
+  {
+    name: "logs.foodLogs.setDay",
+    kind: "mutation",
+    fn: api.logs.foodLogs.setDay,
+    args: { date: "2026-06-25", entries: [] },
+  },
+  {
+    name: "logs.water.setDay",
+    kind: "mutation",
+    fn: api.logs.water.setDay,
+    args: { date: "2026-06-25", entries: [] },
+  },
+  {
+    name: "logs.water.addEntry",
+    kind: "mutation",
+    fn: api.logs.water.addEntry,
+    args: {
+      date: "2026-06-25",
+      entry: {
+        id: "water-1",
+        amountMl: 250,
+        loggedAt: "2026-06-25T08:00:00.000Z",
+      },
+    },
+  },
+  {
+    name: "logs.water.removeEntry",
+    kind: "mutation",
+    fn: api.logs.water.removeEntry,
+    args: { date: "2026-06-25", id: "water-1" },
+  },
+  {
+    name: "logs.presets.create",
+    kind: "mutation",
+    fn: api.logs.presets.create,
+    args: presetBody,
+  },
+  {
+    name: "logs.presets.update",
+    kind: "mutation",
+    fn: api.logs.presets.update,
+    args: { id: fakeId, ...presetBody },
+  },
+  {
+    name: "logs.presets.remove",
+    kind: "mutation",
+    fn: api.logs.presets.remove,
+    args: { id: fakeId },
+  },
+  {
+    name: "logs.recipes.save",
+    kind: "mutation",
+    fn: api.logs.recipes.save,
+    args: { name: "Protected recipe", ingredients: [recipeIngredient] },
+  },
+  {
+    name: "logs.recipes.remove",
+    kind: "mutation",
+    fn: api.logs.recipes.remove,
+    args: { id: fakeId },
+  },
+  {
+    name: "logs.activeWorkout.createActive",
+    kind: "mutation",
+    fn: api.logs.activeWorkout.createActive,
+    args: { slot: 1, items: [], exerciseData: {} },
+  },
+  {
+    name: "logs.activeWorkout.updateActive",
+    kind: "mutation",
+    fn: api.logs.activeWorkout.updateActive,
+    args: { slot: 1, items: [], exerciseData: {}, elapsedSeconds: 1 },
+  },
+  {
+    name: "logs.activeWorkout.abortActive",
+    kind: "mutation",
+    fn: api.logs.activeWorkout.abortActive,
+    args: { slot: 1 },
+  },
+  {
+    name: "logs.activeWorkout.finishActive",
+    kind: "mutation",
+    fn: api.logs.activeWorkout.finishActive,
+    args: { slot: 1, exercises: [workoutExercise], durationSeconds: 60 },
+  },
+  {
+    name: "logs.calories.setProfile",
+    kind: "mutation",
+    fn: api.logs.calories.setProfile,
+    args: healthProfile,
+  },
+  {
+    name: "logs.workouts.completion",
+    kind: "mutation",
+    fn: api.logs.workouts.completion,
+    args: {
+      date: "2026-06-25",
+      exercises: [workoutExercise],
+      durationSeconds: 60,
+    },
+  },
+  {
+    name: "logs.workouts.remove",
+    kind: "mutation",
+    fn: api.logs.workouts.remove,
+    args: { id: fakeId },
+  },
+  {
+    name: "logs.workouts.removeBySlot",
+    kind: "mutation",
+    fn: api.logs.workouts.removeBySlot,
+    args: { date: "2026-06-25", slot: 1 },
+  },
+  {
+    name: "food.openFoodFacts.proxy",
+    kind: "action",
+    fn: api.food.openFoodFacts.proxy,
+    args: { path: "/cgi/search.pl", params: [] },
+  },
+  {
+    name: "logs.snap.snap",
+    kind: "action",
+    fn: api.logs.snap.snap,
+    args: { base64Image: "", mimeType: "image/jpeg" },
+  },
+];
+
+describe("Convex public write authorization", () => {
+  for (const testCase of unauthenticatedWriteCases) {
+    test(`${testCase.name} rejects unauthenticated callers`, async () => {
+      const t = convexTest(schema, modules);
+
+      if (testCase.kind === "mutation") {
+        await expect(t.mutation(testCase.fn, testCase.args)).rejects.toThrow();
+      } else {
+        await expect(t.action(testCase.fn, testCase.args)).rejects.toThrow();
+      }
+    });
+  }
+});

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -16,6 +16,7 @@ import type * as http from "../http.js";
 import type * as lib_calculateCalories from "../lib/calculateCalories.js";
 import type * as lib_deleteUserData from "../lib/deleteUserData.js";
 import type * as lib_estimateOnboardingCalories from "../lib/estimateOnboardingCalories.js";
+import type * as lib_onboardingProfiles from "../lib/onboardingProfiles.js";
 import type * as logs_activeWorkout from "../logs/activeWorkout.js";
 import type * as logs_calories from "../logs/calories.js";
 import type * as logs_foodLogs from "../logs/foodLogs.js";
@@ -44,6 +45,7 @@ declare const fullApi: ApiFromModules<{
   "lib/calculateCalories": typeof lib_calculateCalories;
   "lib/deleteUserData": typeof lib_deleteUserData;
   "lib/estimateOnboardingCalories": typeof lib_estimateOnboardingCalories;
+  "lib/onboardingProfiles": typeof lib_onboardingProfiles;
   "logs/activeWorkout": typeof logs_activeWorkout;
   "logs/calories": typeof logs_calories;
   "logs/foodLogs": typeof logs_foodLogs;

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -2,13 +2,25 @@ import { createClient, type GenericCtx } from "@convex-dev/better-auth";
 import { convex, crossDomain } from "@convex-dev/better-auth/plugins";
 import { components } from "./_generated/api";
 import type { DataModel } from "./_generated/dataModel";
-import { query } from "./_generated/server";
+import { internalAction, query } from "./_generated/server";
 import { betterAuth } from "better-auth";
 import authConfig from "./auth.config";
 
 // Primary app origin — set SITE_URL in Convex env vars / .env.local
 const siteUrl = process.env.SITE_URL ?? "https://app.onerep.life";
 const authBaseUrl = process.env.BETTER_AUTH_URL ?? process.env.CONVEX_SITE_URL;
+const authSecret =
+  process.env.BETTER_AUTH_SECRET ??
+  process.env.AUTH_SECRET ??
+  (process.env.VITEST || process.env.NODE_ENV === "test"
+    ? "test-better-auth-secret-12345678901234567890"
+    : undefined);
+
+if (!authSecret) {
+  throw new Error(
+    "BETTER_AUTH_SECRET or AUTH_SECRET must be set for Better Auth. Generate one with `openssl rand -base64 32` and set it in Convex env vars.",
+  );
+}
 
 const localWebOrigins = Array.from({ length: 18 }, (_, index) => {
   const port = 5173 + index;
@@ -150,6 +162,7 @@ function renderAuthEmail({
 export const createAuth = (ctx: GenericCtx<DataModel>) => {
   return betterAuth({
     baseURL: authBaseUrl,
+    secret: authSecret,
     trustedOrigins,
     database: authComponent.adapter(ctx),
     emailAndPassword: {
@@ -211,5 +224,17 @@ export const getCurrentUser = query({
   args: {},
   handler: async (ctx) => {
     return authComponent.getAuthUser(ctx);
+  },
+});
+
+export const rotateAuthKeys = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const auth = createAuth(ctx);
+    const jwks = await auth.api.rotateKeys();
+    return {
+      rotated: true,
+      keyCount: Array.isArray(jwks) ? jwks.length : 0,
+    };
   },
 });

--- a/convex/users/users.ts
+++ b/convex/users/users.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { mutation, query } from "../_generated/server";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
 import { authComponent } from "../auth";
 import { calculateCalories } from "../lib/calculateCalories";
 import { estimateOnboardingCalories } from "../lib/estimateOnboardingCalories";
@@ -8,7 +9,7 @@ import { getLatestOnboardingProfile } from "../lib/onboardingProfiles";
 
 // ── Auth helper ───────────────────────────────────────────────────────────────
 
-async function requireUser(ctx: any) {
+async function requireUser(ctx: QueryCtx | MutationCtx) {
   const user = await authComponent.getAuthUser(ctx);
   if (!user) throw new Error("Not authenticated");
   return user;


### PR DESCRIPTION
## Summary
- Add `BETTER_AUTH_SECRET` to local and Convex environment setup and document how to generate it.
- Harden mobile auth handling by clearing app-owned local storage, signing out once, and redirecting unauthenticated users consistently.
- Keep offline sync from firing when auth is unavailable, and surface unauthenticated errors through the error boundary.
- Add coverage for mobile session cleanup helpers and Convex authorization on public write/action endpoints.
- Wire Better Auth with an explicit secret and add a key rotation internal action for auth maintenance.

## Testing
- `bun test apps/mobile/src/lib/__tests__/auth-session.test.ts`
- `bun test convex/__tests__/authz.convex.test.ts`
- Not run: full app build or end-to-end mobile flows
- Not run: manual auth key rotation in a live Convex environment