### PR TITLE
Use safe auth reads for unauthenticated Convex queries

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -2510,6 +2510,7 @@ export default function App() {
 
   const homeBodyReady =
     bodyMeasurements !== undefined && preferences !== undefined
+  const bodyReminder = preferences?.bodyReminder ?? null
 
   return (
     <div className="desktop-canvas min-h-svh bg-background md:pr-8 md:pl-72">
@@ -2530,11 +2531,9 @@ export default function App() {
           <>
             {bodyMeasurements.length === 0 && (
               <CheckInPrompt
-                reminderEnabled={preferences.bodyReminder?.enabled ?? false}
+                reminderEnabled={bodyReminder?.enabled ?? false}
                 reminderLabel={
-                  preferences.bodyReminder
-                    ? formatReminderLabel(preferences.bodyReminder)
-                    : ""
+                  bodyReminder ? formatReminderLabel(bodyReminder) : ""
                 }
               />
             )}
@@ -2622,7 +2621,7 @@ export default function App() {
                           ) : (
                             <WaterSmall
                               dateKey={selectedDate}
-                              goalMl={preferences.waterGoalMl ?? 2500}
+                              goalMl={waterGoalMl}
                             />
                           )
                       } else if (widget.id === "workout") {

--- a/convex/__tests__/activeWorkout.convex.test.ts
+++ b/convex/__tests__/activeWorkout.convex.test.ts
@@ -11,17 +11,15 @@ const sampleExerciseData = {
 };
 
 describe("activeWorkout Convex functions", () => {
-  test("unauthenticated reads and writes throw", async () => {
+  test("unauthenticated reads return empty state and writes throw", async () => {
     const t = convexTest(schema, modules);
 
     await expect(
       t.query(api.logs.activeWorkout.getActive, { slot: 1 }),
-    ).rejects.toThrow("Unauthenticated");
+    ).resolves.toBeNull();
     await expect(
       t.query(api.logs.activeWorkout.getAllActive, {}),
-    ).rejects.toThrow(
-      "Unauthenticated",
-    );
+    ).resolves.toEqual([]);
     await expect(
       t.mutation(api.logs.activeWorkout.createActive, {
         slot: 1,

--- a/convex/__tests__/bodyProgress.convex.test.ts
+++ b/convex/__tests__/bodyProgress.convex.test.ts
@@ -6,12 +6,10 @@ import { api } from "../_generated/api";
 const modules = import.meta.glob("../**/*.ts");
 
 describe("bodyProgress Convex functions", () => {
-  test("list throws when unauthenticated", async () => {
+  test("list returns empty array when unauthenticated", async () => {
     const t = convexTest(schema, modules);
 
-    await expect(t.query(api.bodyProgress.list, {})).rejects.toThrow(
-      "Unauthenticated",
-    );
+    await expect(t.query(api.bodyProgress.list, {})).resolves.toEqual([]);
   });
 
   test("save throws when unauthenticated", async () => {

--- a/convex/__tests__/calories.convex.test.ts
+++ b/convex/__tests__/calories.convex.test.ts
@@ -50,9 +50,9 @@ describe("calories Convex functions", () => {
     expect(result.targetCalories).toBe(result.tdee + 500);
   });
 
-  test("getGoals throws when unauthenticated", async () => {
+  test("getGoals returns null when unauthenticated", async () => {
     const t = convexTest(schema, modules);
-    await expect(t.query(api.logs.calories.getGoals, {})).rejects.toThrow();
+    await expect(t.query(api.logs.calories.getGoals, {})).resolves.toBeNull();
   });
 
   test("setProfile stores health profile data", async () => {

--- a/convex/__tests__/foodLogs.convex.test.ts
+++ b/convex/__tests__/foodLogs.convex.test.ts
@@ -6,11 +6,11 @@ import { api } from "../_generated/api";
 const modules = import.meta.glob("../**/*.ts");
 
 describe("foodLogs Convex functions", () => {
-  test("getDay throws when unauthenticated", async () => {
+  test("getDay returns empty array when unauthenticated", async () => {
     const t = convexTest(schema, modules);
     await expect(
       t.query(api.logs.foodLogs.getDay, { date: "2024-01-15" })
-    ).rejects.toThrow();
+    ).resolves.toEqual([]);
   });
 
   test("setDay throws when unauthenticated", async () => {

--- a/convex/__tests__/onboarding.convex.test.ts
+++ b/convex/__tests__/onboarding.convex.test.ts
@@ -6,9 +6,9 @@ import { api } from "../_generated/api";
 const modules = import.meta.glob("../**/*.ts");
 
 describe("onboarding Convex functions", () => {
-  test("get throws when unauthenticated", async () => {
+  test("get returns null when unauthenticated", async () => {
     const t = convexTest(schema, modules);
-    await expect(t.query(api.users.onboarding.get, {})).rejects.toThrow();
+    await expect(t.query(api.users.onboarding.get, {})).resolves.toBeNull();
   });
 
   test("save throws when unauthenticated", async () => {

--- a/convex/__tests__/presets.convex.test.ts
+++ b/convex/__tests__/presets.convex.test.ts
@@ -15,9 +15,9 @@ const basePreset = {
 };
 
 describe("presets Convex functions", () => {
-  test("list throws when unauthenticated", async () => {
+  test("list returns empty array when unauthenticated", async () => {
     const t = convexTest(schema, modules);
-    await expect(t.query(api.logs.presets.list, {})).rejects.toThrow();
+    await expect(t.query(api.logs.presets.list, {})).resolves.toEqual([]);
   });
 
   test("create throws when unauthenticated", async () => {

--- a/convex/__tests__/recipes.convex.test.ts
+++ b/convex/__tests__/recipes.convex.test.ts
@@ -16,9 +16,9 @@ const ingredient = {
 };
 
 describe("recipes Convex functions", () => {
-  test("list throws when unauthenticated", async () => {
+  test("list returns empty array when unauthenticated", async () => {
     const t = convexTest(schema, modules);
-    await expect(t.query(api.logs.recipes.list, {})).rejects.toThrow();
+    await expect(t.query(api.logs.recipes.list, {})).resolves.toEqual([]);
   });
 
   test("save throws when unauthenticated", async () => {

--- a/convex/__tests__/schedules.convex.test.ts
+++ b/convex/__tests__/schedules.convex.test.ts
@@ -16,9 +16,9 @@ const routine = {
 };
 
 describe("schedules Convex functions", () => {
-  test("get throws when unauthenticated", async () => {
+  test("get returns null when unauthenticated", async () => {
     const t = convexTest(schema, modules);
-    await expect(t.query(api.users.schedules.get, {})).rejects.toThrow();
+    await expect(t.query(api.users.schedules.get, {})).resolves.toBeNull();
   });
 
   test("set throws when unauthenticated", async () => {

--- a/convex/__tests__/users.convex.test.ts
+++ b/convex/__tests__/users.convex.test.ts
@@ -6,14 +6,14 @@ import { api } from "../_generated/api";
 const modules = import.meta.glob("../**/*.ts");
 
 describe("users Convex functions", () => {
-  test("getCurrentUser throws when unauthenticated", async () => {
+  test("getCurrentUser returns null when unauthenticated", async () => {
     const t = convexTest(schema, modules);
-    await expect(t.query(api.users.users.getCurrentUser, {})).rejects.toThrow();
+    await expect(t.query(api.users.users.getCurrentUser, {})).resolves.toBeNull();
   });
 
-  test("getPreferences throws when unauthenticated", async () => {
+  test("getPreferences returns null when unauthenticated", async () => {
     const t = convexTest(schema, modules);
-    await expect(t.query(api.users.users.getPreferences, {})).rejects.toThrow();
+    await expect(t.query(api.users.users.getPreferences, {})).resolves.toBeNull();
   });
 
   test("syncTimezone throws when unauthenticated", async () => {
@@ -44,9 +44,9 @@ describe("users Convex functions", () => {
     ).rejects.toThrow();
   });
 
-  test("getEffectiveGoals throws when unauthenticated", async () => {
+  test("getEffectiveGoals returns null when unauthenticated", async () => {
     const t = convexTest(schema, modules);
-    await expect(t.query(api.users.users.getEffectiveGoals, {})).rejects.toThrow();
+    await expect(t.query(api.users.users.getEffectiveGoals, {})).resolves.toBeNull();
   });
 
   test("stores user preferences correctly", async () => {

--- a/convex/__tests__/water.convex.test.ts
+++ b/convex/__tests__/water.convex.test.ts
@@ -6,11 +6,11 @@ import { api } from "../_generated/api";
 const modules = import.meta.glob("../**/*.ts");
 
 describe("waterLogs Convex functions", () => {
-  test("getDay throws when unauthenticated", async () => {
+  test("getDay returns empty array when unauthenticated", async () => {
     const t = convexTest(schema, modules);
     await expect(
       t.query(api.logs.water.getDay, { date: "2024-01-15" })
-    ).rejects.toThrow();
+    ).resolves.toEqual([]);
   });
 
   test("setDay throws when unauthenticated", async () => {

--- a/convex/__tests__/workouts.convex.test.ts
+++ b/convex/__tests__/workouts.convex.test.ts
@@ -6,18 +6,18 @@ import { api } from "../_generated/api";
 const modules = import.meta.glob("../**/*.ts");
 
 describe("workoutLogs Convex functions", () => {
-  test("getLog throws when unauthenticated", async () => {
+  test("getLog returns null when unauthenticated", async () => {
     const t = convexTest(schema, modules);
     await expect(
       t.query(api.logs.workouts.getLog, { date: "2024-01-15" })
-    ).rejects.toThrow();
+    ).resolves.toBeNull();
   });
 
-  test("getHistory throws when unauthenticated", async () => {
+  test("getHistory returns empty array when unauthenticated", async () => {
     const t = convexTest(schema, modules);
     await expect(
       t.query(api.logs.workouts.getHistory, {})
-    ).rejects.toThrow();
+    ).resolves.toEqual([]);
   });
 
   test("completion throws when unauthenticated", async () => {

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -216,14 +216,20 @@ export const createAuth = (ctx: GenericCtx<DataModel>) => {
         enabled: true,
       },
     },
-    plugins: [crossDomain({ siteUrl }), convex({ authConfig })],
+    plugins: [
+      crossDomain({ siteUrl }),
+      convex({
+        authConfig,
+        jwksRotateOnTokenGenerationError: true,
+      }),
+    ],
   });
 };
 
 export const getCurrentUser = query({
   args: {},
   handler: async (ctx) => {
-    return authComponent.getAuthUser(ctx);
+    return authComponent.safeGetAuthUser(ctx);
   },
 });
 

--- a/convex/bodyProgress.ts
+++ b/convex/bodyProgress.ts
@@ -7,7 +7,7 @@ import { authComponent } from "./auth";
 export const list = query({
   args: {},
   handler: async (ctx) => {
-    const user = await authComponent.getAuthUser(ctx);
+    const user = await authComponent.safeGetAuthUser(ctx);
     if (!user) return [];
 
     const docs = await ctx.db

--- a/convex/logs/activeWorkout.ts
+++ b/convex/logs/activeWorkout.ts
@@ -7,7 +7,7 @@ import { authComponent } from "../auth";
 export const getActive = query({
   args: { slot: v.union(v.literal(1), v.literal(2)) },
   handler: async (ctx, args) => {
-    const user = await authComponent.getAuthUser(ctx);
+    const user = await authComponent.safeGetAuthUser(ctx);
     if (!user) return null;
 
     const active = await ctx.db
@@ -28,7 +28,7 @@ export const getActive = query({
 export const getAllActive = query({
   args: {},
   handler: async (ctx) => {
-    const user = await authComponent.getAuthUser(ctx);
+    const user = await authComponent.safeGetAuthUser(ctx);
     if (!user) return [];
 
     return ctx.db

--- a/convex/logs/calories.ts
+++ b/convex/logs/calories.ts
@@ -25,7 +25,7 @@ const healthProfileArgs = {
 export const getGoals = query({
   args: {},
   handler: async (ctx): Promise<CaloricGoals | null> => {
-    const user = await authComponent.getAuthUser(ctx);
+    const user = await authComponent.safeGetAuthUser(ctx);
     if (!user) return null;
 
     const profile = await ctx.db
@@ -45,7 +45,7 @@ export const getGoals = query({
 export const getProfile = query({
   args: {},
   handler: async (ctx) => {
-    const user = await authComponent.getAuthUser(ctx);
+    const user = await authComponent.safeGetAuthUser(ctx);
     if (!user) return null;
 
     return await ctx.db

--- a/convex/logs/foodLogs.ts
+++ b/convex/logs/foodLogs.ts
@@ -7,7 +7,7 @@ import { authComponent } from "../auth";
 export const getDay = query({
   args: { date: v.string() },
   handler: async (ctx, args) => {
-    const user = await authComponent.getAuthUser(ctx);
+    const user = await authComponent.safeGetAuthUser(ctx);
     if (!user) return [];
 
     const doc = await ctx.db

--- a/convex/logs/presets.ts
+++ b/convex/logs/presets.ts
@@ -16,7 +16,7 @@ const presetBodyArgs = {
 export const list = query({
   args: {},
   handler: async (ctx) => {
-    const user = await authComponent.getAuthUser(ctx);
+    const user = await authComponent.safeGetAuthUser(ctx);
     if (!user) return [];
 
     const docs = await ctx.db

--- a/convex/logs/recipes.ts
+++ b/convex/logs/recipes.ts
@@ -43,7 +43,7 @@ const recipeIngredientValidator = v.object({
 export const list = query({
   args: {},
   handler: async (ctx) => {
-    const user = await authComponent.getAuthUser(ctx);
+    const user = await authComponent.safeGetAuthUser(ctx);
     if (!user) return [];
     return await ctx.db
       .query("recipes")

--- a/convex/logs/water.ts
+++ b/convex/logs/water.ts
@@ -7,7 +7,7 @@ import { authComponent } from "../auth";
 export const getDay = query({
   args: { date: v.string() },
   handler: async (ctx, args) => {
-    const user = await authComponent.getAuthUser(ctx);
+    const user = await authComponent.safeGetAuthUser(ctx);
     if (!user) return [];
 
     const doc = await ctx.db

--- a/convex/logs/workouts.ts
+++ b/convex/logs/workouts.ts
@@ -60,7 +60,7 @@ export const completion = mutation({
 export const getLog = query({
   args: { date: v.string() },
   handler: async (ctx, args) => {
-    const user = await authComponent.getAuthUser(ctx);
+    const user = await authComponent.safeGetAuthUser(ctx);
     if (!user) return null;
 
     return ctx.db
@@ -77,7 +77,7 @@ export const getLog = query({
 export const getHistory = query({
   args: {},
   handler: async (ctx) => {
-    const user = await authComponent.getAuthUser(ctx);
+    const user = await authComponent.safeGetAuthUser(ctx);
     if (!user) return [];
     return ctx.db
       .query("workoutLogs")
@@ -92,7 +92,7 @@ export const getHistory = query({
 export const historyForExercise = query({
   args: { exerciseId: v.string() },
   handler: async (ctx, { exerciseId }) => {
-    const user = await authComponent.getAuthUser(ctx);
+    const user = await authComponent.safeGetAuthUser(ctx);
     if (!user) return [];
     const logs = await ctx.db
       .query("workoutLogs")

--- a/convex/users/onboarding.ts
+++ b/convex/users/onboarding.ts
@@ -16,7 +16,7 @@ async function requireUser(ctx: QueryCtx | MutationCtx) {
 export const get = query({
   args: {},
   handler: async (ctx) => {
-    const user = await authComponent.getAuthUser(ctx);
+    const user = await authComponent.safeGetAuthUser(ctx);
     if (!user) return null;
 
     return await getLatestOnboardingProfile(ctx, user._id);

--- a/convex/users/schedules.ts
+++ b/convex/users/schedules.ts
@@ -7,7 +7,7 @@ import { authComponent } from "../auth";
 export const get = query({
   args: {},
   handler: async (ctx) => {
-    const user = await authComponent.getAuthUser(ctx);
+    const user = await authComponent.safeGetAuthUser(ctx);
     if (!user) return null;
 
     return ctx.db

--- a/convex/users/users.ts
+++ b/convex/users/users.ts
@@ -18,14 +18,14 @@ async function requireUser(ctx: QueryCtx | MutationCtx) {
 export const getCurrentUser = query({
   args: {},
   handler: async (ctx) => {
-    return authComponent.getAuthUser(ctx);
+    return authComponent.safeGetAuthUser(ctx);
   },
 });
 
 export const getPreferences = query({
   args: {},
   handler: async (ctx) => {
-    const user = await authComponent.getAuthUser(ctx);
+    const user = await authComponent.safeGetAuthUser(ctx);
     if (!user) return null;
     return await ctx.db
       .query("userPreferences")
@@ -497,7 +497,7 @@ export const deleteMyDataBatch = mutation({
 export const getEffectiveGoals = query({
   args: { date: v.optional(v.string()) },
   handler: async (ctx, args) => {
-    const user = await authComponent.getAuthUser(ctx);
+    const user = await authComponent.safeGetAuthUser(ctx);
     if (!user) return null;
 
     const prefs = await ctx.db

--- a/convex/vitest.config.ts
+++ b/convex/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     include: ["convex/__tests__/*.convex.test.ts"],
     environment: "edge-runtime",
+    testTimeout: 20_000,
     server: { deps: { inline: ["convex-test"] } },
   },
 });


### PR DESCRIPTION
## Summary
- Switched several Convex read paths from `getAuthUser` to `safeGetAuthUser` so unauthenticated requests now return empty/null results instead of throwing.
- Updated auth helpers and user-facing queries in logs, body progress, onboarding, schedules, and user preference/goals flows to match the new unauthenticated behavior.
- Enabled JWKS rotation on auth token generation errors and raised the Convex Vitest timeout to reduce flaky test failures.
- Adjusted mobile UI fallbacks so body reminders and water goals read from the new safe/null-friendly values.
- Updated Convex tests to assert the new unauthenticated read behavior explicitly.

## Testing
- Updated unit tests in `convex/__tests__` to expect `null` or `[]` for unauthenticated reads.
- Not run: automated test suite.
- Not run: mobile app build or runtime verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unauthenticated viewing of several sections now returns empty results or `null` instead of errors, making the app behave more gracefully when not signed in.
  * Improved handling for activity, body progress, calories, food logs, presets, recipes, schedules, users, water, and workout history screens.

* **Style**
  * Simplified app logic for reminder and water widget values by reusing shared settings data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->