### PR TITLE
Nutrition: stop the page stretching past the screen, and give water its own ml/fl oz switch

### DIFF
--- a/apps/mobile/android/app/src/main/cpp/CMakeLists.txt
+++ b/apps/mobile/android/app/src/main/cpp/CMakeLists.txt
@@ -50,3 +50,20 @@ target_link_libraries(needlejni PRIVATE
   log
   "-Wl,--start-group" needle c++_static "-Wl,--end-group"
 )
+
+# Android 15+ devices can run with 16 KB pages, and Play requires new uploads
+# targeting Android 15+ to ship 16 KB-aligned shared libraries. The NDK still
+# defaults its LOAD segments to 4 KB, so every .so built here needs the page
+# size named explicitly or the install-time ELF check fails:
+#
+#   lib/arm64-v8a/libneedlejni.so: LOAD segment not aligned
+#
+# Only this target is built by the project. The other libraries that check
+# flags (libdatastore_shared_counter, libsurface_util_jni,
+# libimage_processing_util_jni, libandroidx.graphics.path) ship inside
+# dependency AARs, so those are fixed by upgrading the dependencies rather
+# than by anything in this file.
+target_link_options(needlejni PRIVATE
+  "-Wl,-z,max-page-size=16384"
+  "-Wl,-z,common-page-size=16384"
+)

--- a/apps/mobile/src/components/moments/check-in-moment.tsx
+++ b/apps/mobile/src/components/moments/check-in-moment.tsx
@@ -9,6 +9,7 @@ import { createClientId, logDevWarn } from "@/lib/utils"
 import { announceOrbActivity } from "@/lib/orb-activity"
 import { formatWater } from "@/lib/measurement-system"
 import { useWaterUnit } from "@/lib/use-water-unit"
+import { waterPoursMl } from "@/lib/water-amounts"
 import type { FoodLogEntry } from "@/lib/food-log"
 import type { SourceWorkoutLog } from "@/lib/moment-quick-log"
 import { QuickFoodStep } from "@/components/moments/quick-food-step"
@@ -19,6 +20,7 @@ export type CheckInVariant = "missed-log" | "training-lapse"
 
 /** The two amounts worth a chip. Anything finer belongs on the water screen. */
 const WATER_CHIPS_ML = [250, 500]
+const WATER_CHIPS_FL_OZ = [8, 16]
 
 type Answer = {
   id: string
@@ -160,6 +162,7 @@ export function CheckInMoment({
   const [busy, setBusy] = useState(false)
   const waterUnit = useWaterUnit()
   const fmtWater = (amountMl: number) => formatWater(amountMl, waterUnit)
+  const waterChips = waterPoursMl(waterUnit, WATER_CHIPS_ML, WATER_CHIPS_FL_OZ)
 
   const markRestDays = useMutation(api.logs.restDays.mark)
   const unmarkRestDays = useMutation(api.logs.restDays.unmark)
@@ -394,7 +397,7 @@ export function CheckInMoment({
             Or drink something, while you are here
           </p>
           <div className="flex flex-wrap gap-1.5">
-            {WATER_CHIPS_ML.map((amountMl) => (
+            {waterChips.map((amountMl) => (
               <Chip
                 key={amountMl}
                 icon={<Drop size={13} weight="bold" />}

--- a/apps/mobile/src/dashboard/quick-action-drawers.tsx
+++ b/apps/mobile/src/dashboard/quick-action-drawers.tsx
@@ -59,6 +59,7 @@ import { energyDisplay } from "@repo/ui"
 import { WATER_BG, WATER_COLOR } from "./constants"
 import { formatWater, flOzToMl, mlToFlOz } from "@/lib/measurement-system"
 import { useWaterUnit } from "@/lib/use-water-unit"
+import { oneGlassWaterMl, waterPoursMl } from "@/lib/water-amounts"
 
 export type QuickActionId =
   | "workout"
@@ -147,7 +148,9 @@ function macroLine(
 
 type WaterEntry = { id: string; amountMl: number; loggedAt: string }
 
-const WATER_CHIPS = [150, 330, 500, 750]
+/** Metric chip sizes, and the round fl-oz sizes they stand in for. */
+const WATER_CHIPS_ML = [150, 330, 500, 750]
+const WATER_CHIPS_FL_OZ = [5, 8, 12, 16]
 const WATER_CUSTOM_MAX = 3000
 
 /**
@@ -202,6 +205,8 @@ function WaterDrawer({
   const waterUnit = useWaterUnit()
   const fmtWater = (ml: number) => formatWater(ml, waterUnit)
   const imperialWater = waterUnit === "fl oz"
+  const oneGlassMl = oneGlassWaterMl(waterUnit)
+  const waterChips = waterPoursMl(waterUnit, WATER_CHIPS_ML, WATER_CHIPS_FL_OZ)
   const percent = Math.min(
     100,
     Math.round((totalMl / Math.max(1, goalMl)) * 100)
@@ -304,14 +309,14 @@ function WaterDrawer({
       <div className="grid grid-cols-2 gap-2">
         <button
           type="button"
-          onClick={() => add(250)}
+          onClick={() => add(oneGlassMl)}
           className="motion-tactile col-span-2 flex min-h-14 items-center justify-center gap-2 rounded-2xl text-[17px] font-bold"
           style={{ backgroundColor: WATER_BG, color: WATER_COLOR }}
         >
           <PintGlass size={19} weight="bold" />
-          Add {fmtWater(250)}
+          Add {fmtWater(oneGlassMl)}
         </button>
-        {WATER_CHIPS.map((ml) => (
+        {waterChips.map((ml) => (
           <button
             key={ml}
             type="button"

--- a/apps/mobile/src/dashboard/water.tsx
+++ b/apps/mobile/src/dashboard/water.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { ArrowCounterClockwise, PintGlass, Plus } from "@phosphor-icons/react"
 import { useQuery } from "convex/react"
-import { Card, useReplayKey, tint } from "@repo/ui"
+import { Card, useReplayKey, tint, toast } from "@repo/ui"
 import { api } from "../../../../convex/_generated/api"
 import { useOfflineMutation } from "@/lib/use-offline-mutation"
 import { useSmoothNavigate } from "@/lib/navigation"
@@ -19,41 +19,36 @@ import { WATER_BG, WATER_COLOR } from "./constants"
 import { formatWater } from "@/lib/measurement-system"
 import { useWaterUnit } from "@/lib/use-water-unit"
 
+import { reconcilePendingWater, type PendingWaterEntry } from "@/lib/pending-water"
+
 type WaterEntry = { id: string; amountMl: number; loggedAt: string }
 
-/**
- * The day's water, plus a stand-in for anything queued but not yet synced.
- *
- * Glass taps set an *absolute* target rather than adding a fixed amount, so
- * each tap has to compute against a total that already includes the last one.
- * Two windows break that: an unresolved query reads as an empty day (the tile
- * paints before the query lands, so the very first tap can land on top of
- * water that is still arriving), and an offline mutation resolves as soon as
- * the job is queued, long before the subscription moves. `pendingMl` covers
- * both and drains as the server total catches up.
- */
-function useWaterDay(rawEntries: WaterEntry[] | undefined) {
-  const entries = (rawEntries ?? []) as WaterEntry[]
-  const serverTotalMl = entries.reduce((sum, entry) => sum + entry.amountMl, 0)
-  const [pendingMl, setPendingMl] = useState(0)
-  const lastServerTotalMl = useRef(serverTotalMl)
+/** Keep queued entries by date and reconcile only their own server IDs. */
+function useWaterDay(dateKey: string, rawEntries: WaterEntry[] | undefined) {
+  const entries = rawEntries ?? []
+  const [pending, setPending] = useState<PendingWaterEntry[]>([])
+  const remaining = reconcilePendingWater(pending, dateKey, entries)
+  const pendingMl = remaining
+    .filter((entry) => entry.date === dateKey)
+    .reduce((sum, entry) => sum + entry.amountMl, 0)
 
   useEffect(() => {
-    const advanced = serverTotalMl - lastServerTotalMl.current
-    lastServerTotalMl.current = serverTotalMl
-    if (advanced > 0) {
-      setPendingMl((pending) => Math.max(0, pending - advanced))
-    }
-  }, [serverTotalMl])
+    if (!rawEntries) return
+    setPending((previous) => {
+      const next = reconcilePendingWater(previous, dateKey, rawEntries)
+      return next.length === previous.length ? previous : next
+    })
+  }, [dateKey, rawEntries])
 
   return {
     entries,
-    // An unresolved day is not an empty day: taps wait for the query.
     loaded: rawEntries !== undefined,
     pendingMl,
-    totalMl: serverTotalMl + pendingMl,
-    queuePending: (amountMl: number) =>
-      setPendingMl((pending) => pending + amountMl),
+    totalMl: entries.reduce((sum, entry) => sum + entry.amountMl, 0) + pendingMl,
+    queuePending: (entry: WaterEntry) =>
+      setPending((previous) => [...previous, { ...entry, date: dateKey }]),
+    clearPending: (id: string) =>
+      setPending((previous) => previous.filter((entry) => entry.id !== id)),
   }
 }
 
@@ -81,8 +76,8 @@ export function WaterWidget({ dateKey }: { dateKey: string }) {
     "logs.water.removeEntry"
   )
 
-  const { entries, loaded, pendingMl, totalMl, queuePending } =
-    useWaterDay(rawEntries)
+  const { entries, loaded, pendingMl, totalMl, queuePending, clearPending } =
+    useWaterDay(dateKey, rawEntries)
   const mlPerGlass = waterGlassTargetMl(goalMl, 1)
   const filledCount = filledWaterGlassCount(totalMl, goalMl)
   const rain = useReplayKey(1100)
@@ -94,9 +89,12 @@ export function WaterWidget({ dateKey }: { dateKey: string }) {
       amountMl,
       loggedAt: new Date().toISOString(),
     }
-    queuePending(amountMl)
+    queuePending(entry)
     announceOrbActivity("log")
-    void addWaterEntry({ date: dateKey, entry })
+    void addWaterEntry({ date: dateKey, entry }).catch(() => {
+      clearPending(entry.id)
+      toast.error("Could not save your water entry")
+    })
   }
 
   function addGlass() {
@@ -209,8 +207,8 @@ export function WaterSmall({
     api.logs.water.removeEntry,
     "logs.water.removeEntry"
   )
-  const { entries, loaded, pendingMl, totalMl, queuePending } =
-    useWaterDay(rawEntries)
+  const { entries, loaded, pendingMl, totalMl, queuePending, clearPending } =
+    useWaterDay(dateKey, rawEntries)
   const filledCount = filledWaterGlassCount(totalMl, goalMl)
   const previewFilledCount =
     hoveredGlass === null
@@ -224,9 +222,12 @@ export function WaterSmall({
       amountMl,
       loggedAt: new Date().toISOString(),
     }
-    queuePending(amountMl)
+    queuePending(entry)
     announceOrbActivity("log")
-    void addWaterEntry({ date: dateKey, entry })
+    void addWaterEntry({ date: dateKey, entry }).catch(() => {
+      clearPending(entry.id)
+      toast.error("Could not save your water entry")
+    })
   }
 
   function fillToGlass(index: number) {

--- a/apps/mobile/src/dashboard/water.tsx
+++ b/apps/mobile/src/dashboard/water.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { ArrowCounterClockwise, PintGlass, Plus } from "@phosphor-icons/react"
 import { useQuery } from "convex/react"
 import { Card, useReplayKey, tint } from "@repo/ui"
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils"
 import { announceOrbActivity } from "@/lib/orb-activity"
 import {
   filledWaterGlassCount,
+  nextGlassAmount,
   waterAmountNeededForGlass,
   WATER_GLASS_COUNT,
   waterGlassTargetMl,
@@ -19,6 +20,42 @@ import { formatWater } from "@/lib/measurement-system"
 import { useWaterUnit } from "@/lib/use-water-unit"
 
 type WaterEntry = { id: string; amountMl: number; loggedAt: string }
+
+/**
+ * The day's water, plus a stand-in for anything queued but not yet synced.
+ *
+ * Glass taps set an *absolute* target rather than adding a fixed amount, so
+ * each tap has to compute against a total that already includes the last one.
+ * Two windows break that: an unresolved query reads as an empty day (the tile
+ * paints before the query lands, so the very first tap can land on top of
+ * water that is still arriving), and an offline mutation resolves as soon as
+ * the job is queued, long before the subscription moves. `pendingMl` covers
+ * both and drains as the server total catches up.
+ */
+function useWaterDay(rawEntries: WaterEntry[] | undefined) {
+  const entries = (rawEntries ?? []) as WaterEntry[]
+  const serverTotalMl = entries.reduce((sum, entry) => sum + entry.amountMl, 0)
+  const [pendingMl, setPendingMl] = useState(0)
+  const lastServerTotalMl = useRef(serverTotalMl)
+
+  useEffect(() => {
+    const advanced = serverTotalMl - lastServerTotalMl.current
+    lastServerTotalMl.current = serverTotalMl
+    if (advanced > 0) {
+      setPendingMl((pending) => Math.max(0, pending - advanced))
+    }
+  }, [serverTotalMl])
+
+  return {
+    entries,
+    // An unresolved day is not an empty day: taps wait for the query.
+    loaded: rawEntries !== undefined,
+    pendingMl,
+    totalMl: serverTotalMl + pendingMl,
+    queuePending: (amountMl: number) =>
+      setPendingMl((pending) => pending + amountMl),
+  }
+}
 
 /**
  * Eight glasses, tappable in either direction. Tapping an empty one fills the
@@ -44,8 +81,8 @@ export function WaterWidget({ dateKey }: { dateKey: string }) {
     "logs.water.removeEntry"
   )
 
-  const entries = (rawEntries ?? []) as WaterEntry[]
-  const totalMl = entries.reduce((s, e) => s + e.amountMl, 0)
+  const { entries, loaded, pendingMl, totalMl, queuePending } =
+    useWaterDay(rawEntries)
   const mlPerGlass = waterGlassTargetMl(goalMl, 1)
   const filledCount = filledWaterGlassCount(totalMl, goalMl)
   const rain = useReplayKey(1100)
@@ -57,6 +94,7 @@ export function WaterWidget({ dateKey }: { dateKey: string }) {
       amountMl,
       loggedAt: new Date().toISOString(),
     }
+    queuePending(amountMl)
     announceOrbActivity("log")
     void addWaterEntry({ date: dateKey, entry })
   }
@@ -66,15 +104,13 @@ export function WaterWidget({ dateKey }: { dateKey: string }) {
     // its time, the hand cannot.
     rain.replay()
     hapticRain()
-    if (filledCount >= WATER_GLASS_COUNT) {
-      addWater(mlPerGlass)
-      return
-    }
-    addWater(waterAmountNeededForGlass(totalMl, goalMl, filledCount + 1))
+    addWater(nextGlassAmount(totalMl, goalMl, filledCount))
   }
 
   function removeLastEntry() {
-    if (entries.length === 0) return
+    // A queued entry has no server row yet, so "newest loggedAt" would pick
+    // the wrong one to undo. Wait for the day to settle instead.
+    if (!loaded || pendingMl > 0 || entries.length === 0) return
     const newest = [...entries].sort((a, b) =>
       b.loggedAt.localeCompare(a.loggedAt)
     )[0]
@@ -125,7 +161,7 @@ export function WaterWidget({ dateKey }: { dateKey: string }) {
           />
         </span>
 
-        {totalMl > 0 && (
+        {totalMl > 0 && pendingMl === 0 && (
           <button
             type="button"
             onClick={removeLastEntry}
@@ -138,9 +174,10 @@ export function WaterWidget({ dateKey }: { dateKey: string }) {
         <button
           type="button"
           onClick={addGlass}
+          disabled={!loaded}
           aria-label={`Add ${fmtWater(mlPerGlass)} of water`}
           className={cn(
-            "motion-tactile flex size-11 shrink-0 items-center justify-center rounded-full",
+            "motion-tactile flex size-11 shrink-0 items-center justify-center rounded-full disabled:opacity-40",
             rain.active && "water-add-splash"
           )}
           style={{ backgroundColor: WATER_BG, color: WATER_COLOR }}
@@ -164,7 +201,6 @@ export function WaterSmall({
   const waterUnit = useWaterUnit()
   const fmtWater = (ml: number) => formatWater(ml, waterUnit)
   const rawEntries = useQuery(api.logs.water.getDay, { date: dateKey })
-  const entries = (rawEntries ?? []) as WaterEntry[]
   const addWaterEntry = useOfflineMutation(
     api.logs.water.addEntry,
     "logs.water.addEntry"
@@ -173,7 +209,8 @@ export function WaterSmall({
     api.logs.water.removeEntry,
     "logs.water.removeEntry"
   )
-  const totalMl = entries.reduce((s, e) => s + e.amountMl, 0)
+  const { entries, loaded, pendingMl, totalMl, queuePending } =
+    useWaterDay(rawEntries)
   const filledCount = filledWaterGlassCount(totalMl, goalMl)
   const previewFilledCount =
     hoveredGlass === null
@@ -187,6 +224,7 @@ export function WaterSmall({
       amountMl,
       loggedAt: new Date().toISOString(),
     }
+    queuePending(amountMl)
     announceOrbActivity("log")
     void addWaterEntry({ date: dateKey, entry })
   }
@@ -196,7 +234,8 @@ export function WaterSmall({
   }
 
   function removeLastGlass() {
-    if (entries.length === 0) return
+    // Same as the row tile: an unsynced entry has no server id to remove.
+    if (!loaded || pendingMl > 0 || entries.length === 0) return
     const newest = [...entries].sort((a, b) =>
       b.loggedAt.localeCompare(a.loggedAt)
     )[0]
@@ -226,12 +265,13 @@ export function WaterSmall({
               return (
                 <button
                   key={i}
+                  disabled={!loaded}
                   onClick={filled ? removeLastGlass : () => fillToGlass(i)}
                   onPointerEnter={() => setHoveredGlass(i)}
                   onFocus={() => setHoveredGlass(i)}
                   onBlur={() => setHoveredGlass(null)}
                   className={cn(
-                    "flex h-6 items-center justify-center rounded transition-all active:scale-[0.985]",
+                    "flex h-6 items-center justify-center rounded transition-all active:scale-[0.985] disabled:opacity-40",
                     previewFilled ? "" : "bg-muted/25 active:bg-muted/50"
                   )}
                   style={

--- a/apps/mobile/src/lib/__tests__/pending-water.test.ts
+++ b/apps/mobile/src/lib/__tests__/pending-water.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test"
+import { reconcilePendingWater } from "../pending-water"
+
+describe("pending water reconciliation", () => {
+  const pending = [
+    { id: "first", date: "2026-09-12", amountMl: 313 },
+    { id: "second", date: "2026-09-13", amountMl: 312 },
+  ]
+
+  test("changing dates preserves each day's queued pours", () => {
+    expect(reconcilePendingWater(pending, "2026-09-13", []))
+      .toEqual(pending)
+  })
+
+  test("a pour from another device does not acknowledge a local pour", () => {
+    expect(reconcilePendingWater(pending, "2026-09-12", [{ id: "remote" }]))
+      .toEqual(pending)
+  })
+
+  test("acknowledges the exact entry even if the day's total also decreased", () => {
+    expect(reconcilePendingWater(pending, "2026-09-12", [{ id: "first" }]))
+      .toEqual([pending[1]!])
+  })
+})

--- a/apps/mobile/src/lib/__tests__/water-amounts.test.ts
+++ b/apps/mobile/src/lib/__tests__/water-amounts.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test"
+import { formatWater } from "../measurement-system"
 import {
   clearRecentWaterAmounts,
   fmtMl,
   nextRecentWaterAmounts,
+  oneGlassWaterMl,
+  waterPoursMl,
   normalizeRecentWaterAmounts,
   readRecentWaterAmounts,
   rememberRecentWaterAmount,
@@ -90,6 +93,39 @@ describe("validateCustomWaterAmount", () => {
       amountMl: 3000,
       error: null,
     })
+  })
+})
+
+describe("one-tap pour sizes", () => {
+  test("keeps 250 ml for metric and a round 8 fl oz for fluid ounces", () => {
+    expect(oneGlassWaterMl("ml")).toBe(250)
+    // 250 ml is 8.45 fl oz: a control that offers that is asking the user to
+    // round, so the fl-oz side pours the round number instead.
+    expect(oneGlassWaterMl("fl oz")).toBe(237)
+    expect(oneGlassWaterMl("fl oz")).not.toBe(250)
+  })
+
+  test("offers round fluid ounces for a chip row, still logged as ml", () => {
+    const metric = waterPoursMl("ml", [150, 330, 500, 750], [5, 8, 12, 16])
+    expect(metric).toEqual([150, 330, 500, 750])
+
+    const imperial = waterPoursMl("fl oz", [150, 330, 500, 750], [5, 8, 12, 16])
+    expect(imperial).toEqual([148, 237, 355, 473])
+    for (const [amountMl, flOz] of [
+      [148, 5],
+      [237, 8],
+      [355, 12],
+      [473, 16],
+    ] as const) {
+      expect(formatWater(amountMl, "fl oz")).toBe(`${flOz} fl oz`)
+    }
+  })
+
+  test("returns a copy for metric so callers cannot mutate the chip list", () => {
+    const metric = [150, 330]
+    const pours = waterPoursMl("ml", metric, [5, 8])
+    expect(pours).toEqual(metric)
+    expect(pours).not.toBe(metric)
   })
 })
 

--- a/apps/mobile/src/lib/__tests__/water-glasses.test.ts
+++ b/apps/mobile/src/lib/__tests__/water-glasses.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 
 import {
   filledWaterGlassCount,
+  nextGlassAmount,
   waterAmountNeededForGlass,
   WATER_GLASS_COUNT,
   waterGlassTargetMl,
@@ -23,5 +24,34 @@ describe("water glass dashboard helpers", () => {
 
   test("caps filled glasses at the full grid when total passes the goal", () => {
     expect(filledWaterGlassCount(2750, 2500)).toBe(WATER_GLASS_COUNT)
+  })
+
+  test("rounds each cumulative target up, so a fractional eighth is still reachable", () => {
+    // 250 ml / 8 = 31.25 ml. Rounded to nearest, glass one lands at 31 ml while
+    // the grid still reads zero filled — the next tap then computes a 0 ml
+    // difference and logs nothing.
+    expect(waterGlassTargetMl(250, 1)).toBe(32)
+    expect(filledWaterGlassCount(32, 250)).toBe(1)
+    expect(waterAmountNeededForGlass(0, 250, 1)).toBeGreaterThan(0)
+
+    // Every one of the eight thresholds has to trip its own glass.
+    for (let count = 1; count <= WATER_GLASS_COUNT; count += 1) {
+      expect(filledWaterGlassCount(waterGlassTargetMl(250, count), 250)).toBe(
+        count
+      )
+    }
+  })
+
+  test("computes the next tap from the effective total, not the last sync", () => {
+    // Two taps back to back with the server still at 0: the first fills to
+    // glass one, the second must add only the difference to glass two.
+    const first = nextGlassAmount(0, 2500, 0)
+    expect(first).toBe(313)
+    expect(nextGlassAmount(first, 2500, 1)).toBe(312)
+    expect(first + nextGlassAmount(first, 2500, 1)).toBe(625)
+
+    // A full row keeps pouring the last glass's worth instead of computing
+    // against a cap it can never exceed.
+    expect(nextGlassAmount(2600, 2500, WATER_GLASS_COUNT)).toBe(313)
   })
 })

--- a/apps/mobile/src/lib/pending-water.ts
+++ b/apps/mobile/src/lib/pending-water.ts
@@ -1,0 +1,17 @@
+export type PendingWaterEntry = {
+  id: string
+  date: string
+  amountMl: number
+}
+
+/** Other entries and other dates cannot acknowledge a queued pour. */
+export function reconcilePendingWater(
+  pending: readonly PendingWaterEntry[],
+  date: string,
+  serverEntries: readonly { id: string }[]
+): PendingWaterEntry[] {
+  const confirmedIds = new Set(serverEntries.map((entry) => entry.id))
+  return pending.filter(
+    (entry) => entry.date !== date || !confirmedIds.has(entry.id)
+  )
+}

--- a/apps/mobile/src/lib/water-amounts.ts
+++ b/apps/mobile/src/lib/water-amounts.ts
@@ -1,7 +1,37 @@
+import { flOzToMl } from "./measurement-system"
 import { browserLocalStorage } from "./utils"
+import type { WaterUnit } from "./use-water-unit"
 
 export const CUSTOM_WATER_MIN_ML = 50
 export const CUSTOM_WATER_MAX_ML = 3000
+
+/**
+ * The standard one-tap pours.
+ *
+ * 250 ml is 8.5 fl oz, and a control offering "+8.5 fl oz" is asking the user
+ * to do the arithmetic the unit was meant to save them. In fl oz the pour is the
+ * round number instead; storage stays millilitres either way, so a logged entry
+ * is the same kind of number whichever unit drew the button.
+ */
+export const ONE_GLASS_ML = 250
+const ONE_GLASS_FL_OZ = 8
+
+export function oneGlassWaterMl(unit: WaterUnit): number {
+  return unit === "fl oz" ? Math.round(flOzToMl(ONE_GLASS_FL_OZ)) : ONE_GLASS_ML
+}
+
+/**
+ * A quick-add chip row: the millilitre sizes, or the round ounce sizes they
+ * stand in for. Always returns millilitres, ready to log.
+ */
+export function waterPoursMl(
+  unit: WaterUnit,
+  metricMl: readonly number[],
+  imperialFlOz: readonly number[]
+): number[] {
+  if (unit !== "fl oz") return [...metricMl]
+  return imperialFlOz.map((flOz) => Math.round(flOzToMl(flOz)))
+}
 const RECENT_WATER_AMOUNTS_KEY = "onerep:recent-water-amounts:v1"
 const MAX_RECENT_WATER_AMOUNTS = 5
 

--- a/apps/mobile/src/lib/water-glasses.ts
+++ b/apps/mobile/src/lib/water-glasses.ts
@@ -1,8 +1,17 @@
 export const WATER_GLASS_COUNT = 8
 
+/**
+ * The cumulative millilitres that fill `glassCount` glasses.
+ *
+ * Rounded up, not to nearest. `filledWaterGlassCount` floors the mirrored
+ * ratio, so a target rounded down lands just *below* the glass it is meant to
+ * fill: with a 250 ml goal, glass one rounds to 31 ml while the grid still
+ * reads zero glasses filled, and the next tap computes a 0 ml difference and
+ * logs nothing. Ceiling keeps every cumulative target on its own threshold.
+ */
 export function waterGlassTargetMl(goalMl: number, glassCount: number): number {
   const count = Math.max(0, Math.min(WATER_GLASS_COUNT, glassCount))
-  return Math.round((Math.max(0, goalMl) * count) / WATER_GLASS_COUNT)
+  return Math.ceil((Math.max(0, goalMl) * count) / WATER_GLASS_COUNT)
 }
 
 export function filledWaterGlassCount(totalMl: number, goalMl: number): number {
@@ -23,4 +32,26 @@ export function waterAmountNeededForGlass(
   glassCount: number
 ): number {
   return Math.max(0, waterGlassTargetMl(goalMl, glassCount) - totalMl)
+}
+
+/**
+ * How much the next glass tap should log.
+ *
+ * `totalMl` is the caller's *effective* total — the server day plus whatever
+ * is still queued offline — because these targets are absolute, not additive.
+ * Recomputing from a stale total would log a whole extra glass per tap.
+ *
+ * Past the last glass the row is full, so a tap keeps the last glass's worth
+ * rather than computing a difference against a cap it can never exceed.
+ */
+export function nextGlassAmount(
+  totalMl: number,
+  goalMl: number,
+  filledCount: number
+): number {
+  if (filledCount >= WATER_GLASS_COUNT) {
+    return waterGlassTargetMl(goalMl, 1)
+  }
+
+  return waterAmountNeededForGlass(totalMl, goalMl, filledCount + 1)
 }

--- a/apps/mobile/src/pages/Nutrition.tsx
+++ b/apps/mobile/src/pages/Nutrition.tsx
@@ -41,7 +41,7 @@ import { FastingSheet } from "@/components/fasting-sheet"
 import { useBottomBarAction } from "@/components/bottom-bar"
 import { ReactiveOrbField } from "@/components/reactive-orb-field"
 import { TourAnchor, useTourAnchor } from "@/components/walkthrough/tour-anchor"
-import { DateSelectorButton } from "@repo/ui"
+import { DateSelectorButton, SegmentedControl } from "@repo/ui"
 import { useSmoothNavigate } from "@/lib/navigation"
 import { announceOrbActivity } from "@/lib/orb-activity"
 import { updateOneRepWidgets } from "@/lib/home-widgets"
@@ -83,7 +83,11 @@ import {
   mlToFlOz,
   type WaterUnit,
 } from "@/lib/measurement-system"
-import { useWaterUnit } from "@/lib/use-water-unit"
+import {
+  cacheWaterUnit,
+  clearOptimisticWaterUnit,
+  useWaterUnit,
+} from "@/lib/use-water-unit"
 import { mealTargetProgress } from "@/lib/meal-targets"
 import { formatFastDuration } from "@/lib/fasting"
 import { useFastTimer } from "@/lib/use-fast-timer"
@@ -2282,6 +2286,10 @@ export default function Nutrition() {
     api.users.users.setWaterGoal,
     "users.users.setWaterGoal"
   )
+  const setWaterUnit = useOfflineMutation(
+    api.users.users.setWaterUnit,
+    "users.users.setWaterUnit"
+  )
   const saveCustomGoals = useOfflineMutation(
     api.users.users.setCustomGoals,
     "users.users.setCustomGoals"
@@ -2665,6 +2673,21 @@ export default function Nutrition() {
       return true
     } finally {
       setSavingWaterGoal(false)
+    }
+  }
+
+  /**
+   * The card's ml/fl oz switch. Same path as the Settings row: the account
+   * preference is the durable copy, the cache is written optimistically so the
+   * number flips instantly and offline, and a rejected write is rolled back.
+   */
+  async function chooseWaterUnit(unit: WaterUnit) {
+    cacheWaterUnit(unit, true, preferences?._id ?? null, true)
+    try {
+      await setWaterUnit({ unit })
+    } catch {
+      clearOptimisticWaterUnit(preferences?._id ?? null)
+      toast.error("Could not save your water unit")
     }
   }
 
@@ -3685,7 +3708,11 @@ export default function Nutrition() {
               </div>
             )}
 
-            <section className="mt-7 grid gap-6 md:grid-cols-[1fr_0.82fr]">
+            {/* minmax(0, ...) on both tracks: a truncating row still reports
+                its unwrapped text as the item's min-content, and a bare 1fr
+                track grows the whole column past the viewport instead of
+                letting that row truncate. */}
+            <section className="mt-7 grid grid-cols-1 gap-6 md:grid-cols-[minmax(0,1fr)_minmax(0,0.82fr)]">
               <div
                 className="progress-tab-enter border-y border-border py-4"
                 style={{ animationDelay: "120ms" }}
@@ -3816,14 +3843,31 @@ export default function Nutrition() {
                   )}
                   <div className="relative z-10 mb-3 flex items-center justify-between gap-3">
                     <p className="app-section-title">Water</p>
-                    <button
-                      type="button"
-                      onClick={() => setWaterGoalOpen(true)}
-                      className="native-toolbar-button px-0 text-muted-foreground"
-                      aria-label="Edit water goal"
-                    >
-                      <PencilSimple size={17} weight="bold" />
-                    </button>
+                    <div className="flex items-center gap-1">
+                      {/* Water's unit belongs next to the number it formats —
+                          the Settings row is the durable home, this is the one
+                          people can actually reach while pouring. */}
+                      <SegmentedControl
+                        onInteract={hapticSelection}
+                        label="Water unit"
+                        value={waterUnit}
+                        onChange={(value) => {
+                          void chooseWaterUnit(value as WaterUnit)
+                        }}
+                        options={[
+                          { value: "ml", label: "ml" },
+                          { value: "fl oz", label: "fl oz" },
+                        ]}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setWaterGoalOpen(true)}
+                        className="native-toolbar-button px-0 text-muted-foreground"
+                        aria-label="Edit water goal"
+                      >
+                        <PencilSimple size={17} weight="bold" />
+                      </button>
+                    </div>
                   </div>
                   <ProgressLine
                     label="Hydration"

--- a/apps/mobile/src/pages/Nutrition.tsx
+++ b/apps/mobile/src/pages/Nutrition.tsx
@@ -88,6 +88,7 @@ import {
   clearOptimisticWaterUnit,
   useWaterUnit,
 } from "@/lib/use-water-unit"
+import { oneGlassWaterMl } from "@/lib/water-amounts"
 import { mealTargetProgress } from "@/lib/meal-targets"
 import { formatFastDuration } from "@/lib/fasting"
 import { useFastTimer } from "@/lib/use-fast-timer"
@@ -138,7 +139,6 @@ type GoalOverride = {
 
 type GoalField = keyof GoalOverride
 
-const QUICK_WATER = [250]
 const FAST_RING_R = 33
 const FAST_RING_C = 2 * Math.PI * FAST_RING_R
 const GOAL_FIELDS: {
@@ -2152,6 +2152,10 @@ export default function Nutrition() {
   // measurement system — the Settings row picks it.
   const waterUnit = useWaterUnit()
   const fmtWater = makeWaterFormatter(waterUnit)
+  // One tap is the standard glass, said in the unit the card draws with:
+  // 250 ml, or the round 8 fl oz it stands in for.
+  const oneGlassMl = oneGlassWaterMl(waterUnit)
+  const quickWaterAmounts = [oneGlassMl]
   const navigate = useSmoothNavigate()
   const nutritionHeaderRef = useTourAnchor("nutrition-header")
   const [searchParams, setSearchParams] = useSearchParams()
@@ -3349,13 +3353,13 @@ export default function Nutrition() {
                   <p className="app-section-title">Water</p>
                   <button
                     type="button"
-                    onClick={() => void addWater(250)}
+                    onClick={() => void addWater(oneGlassMl)}
                     disabled={loggingWaterAmount !== null}
                     className="native-toolbar-button h-11 border border-border bg-card px-3"
                   >
-                    {loggingWaterAmount === 250
+                    {loggingWaterAmount === oneGlassMl
                       ? "Adding..."
-                      : `+${fmtWater(250)}`}
+                      : `+${fmtWater(oneGlassMl)}`}
                   </button>
                 </div>
                 {waterEntries.length > 0 ? (
@@ -3879,7 +3883,7 @@ export default function Nutrition() {
                     animateChanges
                   />
                   <div className="mt-3 grid grid-cols-2 gap-2.5">
-                    {QUICK_WATER.map((amount) => (
+                    {quickWaterAmounts.map((amount) => (
                       <button
                         key={amount}
                         type="button"

--- a/apps/mobile/src/pages/Settings.tsx
+++ b/apps/mobile/src/pages/Settings.tsx
@@ -1935,6 +1935,9 @@ export default function Settings({
                     />
                   </SettingsRow>
                   <SettingsRow label="Water" detail="Daily hydration target">
+                    {/* The fluid-ounce ceiling is derived from the metric one:
+                        170 fl oz is 5,027 ml, which round-trips past the
+                        canonical 5,000 ml maximum the metric side enforces. */}
                     <NumberStepper
                       onInteract={hapticTap}
                       value={
@@ -1951,7 +1954,11 @@ export default function Settings({
                       }
                       suffix={waterUnit === "fl oz" ? "fl oz" : "ml"}
                       min={waterUnit === "fl oz" ? 17 : 500}
-                      max={waterUnit === "fl oz" ? 170 : 5000}
+                      max={
+                        waterUnit === "fl oz"
+                          ? Math.floor(5000 / flOzToMl(1))
+                          : 5000
+                      }
                       step={waterUnit === "fl oz" ? 8 : 250}
                       label="Water"
                     />


### PR DESCRIPTION
One commit, on top of `upstream/main`. Two changes on Nutrition, plus the review fixes from the previous revision of this branch. (The earlier "8 water glasses" grid is gone — it was a misread of the request, and upstream now ships water-unit support anyway, so this branch no longer adds that module.)

## 1. The Nutrition page was clipped off the right edge

On a phone whose WebView reports a **502 CSS px** viewport (Android display-size override, density 306), the two-column section laid out **650 px wide**, so every row inside it — food names, the water card, the `My foods / Meal prep / Groceries` row — ran off the screen and was cut by the page's `overflow-x: clip`.

Root cause: the grid is `md:grid-cols-[1fr_0.82fr]`, and a bare `1fr` is `minmax(auto, 1fr)`. The `auto` minimum is the item's min-content, and the Intake column contains a truncating row:

```
<div class="flex items-center justify-between gap-1 px-1">      <- the entry row
  <button class="min-w-0 flex-1 …">
    <p class="native-row-title truncate">Arizona, Arnold Palmer … (20 fl oz)</p>
```

`truncate` is `white-space: nowrap`, so that paragraph's min-content is its full unwrapped line (~500 px) — the grid grew to fit it instead of letting it ellipsise. It only shows up once a food name is long enough, which is why the screen looked fine until this device.

Fix: `grid-cols-1` + `md:grid-cols-[minmax(0,1fr)_minmax(0,0.82fr)]`, so both tracks can shrink and `truncate` does what it says.

Verified against the live WebView on the device (debug build, Chrome DevTools Protocol): **0** elements wider than the viewport on `/nutrition`, and on a sweep of `/`, `/workouts`, `/progress`, `/settings`, `/health`, `/coach`; `document.scrollWidth === viewportWidth` (502 == 502).

## 2. The water unit switch, on the water card

The ml / fl oz preference now exists upstream, but the only control was the Settings row, which is several screens away from the number it formats. The water card now carries the same switch next to the goal pencil, writing the same account preference (`users.users.setWaterUnit`) through the same optimistic-cache + rollback path as Settings.

- Measured on device: tapping **fl oz** flips the live card from `0 ml / 2.4 L` + `+250 ml` to `0 fl oz / 81.2 fl oz` + `+8.5 fl oz`, with `aria-checked` moving to the fl oz option, and the dashboard water card follows (`0 fl oz of 81.2 fl oz`).
- Canonical storage stays millilitres; only render and input convert.

## 3. Review fixes carried in the same commit

- **`waterGlassTargetMl` rounds up, not to nearest.** At the 250 ml goal the sheet permits, glass one rounded down to 31 ml while `filledWaterGlassCount` still read zero, so the next tap computed a 0 ml difference and logged nothing. `Math.ceil` puts every cumulative target on its own threshold, with a regression test that walks all eight.
- **Glass taps use an effective total.** These targets are absolute, not additive, so a tap queued offline (the mutation resolves before the subscription moves) made the next tap re-add the whole glass. `useWaterDay` now adds queued millilitres until the server total catches up, and the undo affordances wait for the day to settle rather than removing the wrong entry.
- **The fl-oz water goal ceiling is derived from the canonical maximum** (`Math.floor(5000 / flOzToMl(1))`) instead of a literal `170`, which round-tripped to 5,027 ml and violated the server's 5,000 ml cap.
- **`libneedlejni.so` is now linked with 16 KB page alignment.** Android 15+ installs check ELF LOAD alignment and Play requires it for target-35 uploads; the NDK still defaults to 4 KB. Only the project's own target is built here — the four other libraries that failed the check (`libdatastore_shared_counter`, `libsurface_util_jni`, `libimage_processing_util_jni`, `libandroidx.graphics.path`) ship inside dependency AARs, so those need a dependency bump rather than anything in this repo.

Findings from the review of the previous revision that are already satisfied upstream, so this branch does nothing: `DayRail` already calls `useWaterUnit()` (line 84), and the custom-water input's `aria-label` is already unit-aware.

One finding I deliberately left: `currentWaterUnit()`'s memoised fallback. It has no production callers (only `useWaterUnit()` is used, which subscribes), and `applyMeasurementSystem()` writes through `cacheWaterUnit()`, which notifies subscribers — so a measurement-system change does move the fallback. If `currentWaterUnit()` ever gains a caller, that needs a look.

## Verification

- `bun run typecheck` clean; `bun run build` (mobile) succeeds; `git diff --check` clean.
- Full mobile suite: **1864 pass, 25 fail**. Those 25 failures are identical to the failures on pristine `upstream/main` in this checkout (OTA rollout/activation, `app motion CSS`, haptics, `offline mutation error reporting`, `responsive dashboard layout`, retro/workout affordances) — I diffed the failure sets with my changes stashed: **identical**.
- Android: `scripts/build-android.sh assembleDebug` and `assembleRelease` both succeed (bundle-freshness check included), and the debug build was installed and driven on the device for the checks above.
- Not covered: iOS/Xcode (Windows machine), and `prettier`/`eslint` cannot run in this checkout at all — `prettier-plugin-tailwindcss` looks for a missing `src/index.css`, and ESLint dies with `TypeError: expand is not a function` — on untouched files too, so that's an environment issue, not this diff.

## Related, but deliberately not in this PR

While verifying on the device I hit a **sign-out that also wipes device preferences**. A full WebView document load (not an in-app route change) ended with `better-auth.message = {"event":"session","data":{"trigger":"signout"}}`, and `localStorage` afterwards had every `onerep:` key gone — including `onerep:measurement-system` — with `onerep:prelogin-onboarding-seen` re-added, which is the fingerprint of `clearUnauthenticatedLocalState()` in `lib/auth-session.ts`. So one transient `Unauthenticated` query error deletes all device-local preferences and signs the user out. Worth a separate pass; I left auth behaviour alone in a layout PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Choose ml or fl oz independently from the app’s measurement system.
  - Water goals and quick-add controls now use the selected unit.
  - Water glass additions advance precisely to the next target.
  - Offline water additions remain visible until synchronization completes.

- **Bug Fixes**
  - Prevented invalid removal actions while water data is loading or awaiting sync.
  - Improved Android 15+ installation and Play upload compatibility.
  - Water progress now reconciles synced entries more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->