### PR TITLE
A sign-out should not reset the device's preferences

### DIFF
--- a/apps/mobile/src/lib/__tests__/auth-session.test.ts
+++ b/apps/mobile/src/lib/__tests__/auth-session.test.ts
@@ -66,11 +66,11 @@ describe("auth session helpers", () => {
     expect(isUnauthenticatedError(new Error("Network error"))).toBe(false)
   })
 
-  test("clears app-owned local storage keys only", () => {
+  test("clears app-owned account state and leaves other keys alone", () => {
     localStorage.setItem("onerep:offline-mutation-queue:v1", "[]")
     localStorage.setItem("onerep_custom_meal_categories", "[]")
     localStorage.setItem("convex:auth", "token")
-    localStorage.setItem("theme", "dark")
+    localStorage.setItem("onerep-auth_session", "token")
     localStorage.setItem("external:keep", "value")
 
     clearLocalStorageCache()
@@ -78,8 +78,68 @@ describe("auth session helpers", () => {
     expect(localStorage.getItem("onerep:offline-mutation-queue:v1")).toBeNull()
     expect(localStorage.getItem("onerep_custom_meal_categories")).toBeNull()
     expect(localStorage.getItem("convex:auth")).toBeNull()
-    expect(localStorage.getItem("theme")).toBeNull()
+    expect(localStorage.getItem("onerep-auth_session")).toBeNull()
     expect(localStorage.getItem("external:keep")).toBe("value")
+  })
+
+  test("keeps device preferences through a failed session", () => {
+    // Everything chosen for *this phone*. A transient Unauthenticated error
+    // used to take all of it: the sign-out that follows is no reason to make
+    // someone pick their units, language, and haptics again.
+    const devicePreferences: [string, string][] = [
+      ["theme", "dark"],
+      ["onerep:measurement-system", "imperial"],
+      ["onerep:water-unit:pref1", "fl oz"],
+      ["onerep:water-unit-explicit:pref1", "1"],
+      ["onerep:energy-unit", "Cal"],
+      ["onerep:weight-unit", "lbs"],
+      ["onerep:haptics-enabled", "true"],
+      ["onerep:haptics-strength", "strong"],
+      ["onerep:rest-bell-enabled", "true"],
+      ["onerep:rest-vibration-enabled", "true"],
+      ["onerep:ui-language", "en"],
+      ["onerep:analytics-enabled", "true"],
+      ["onerep:server-override", "{}"],
+      ["onerep:ota:pending-bundle", "{}"],
+      ["onerep:quick-add-hint-seen", "1"],
+      ["onerep:prelogin-onboarding-seen", "true"],
+    ]
+    for (const [key, value] of devicePreferences) {
+      localStorage.setItem(key, value)
+    }
+
+    clearUnauthenticatedLocalState()
+
+    for (const [key, value] of devicePreferences) {
+      expect(localStorage.getItem(key)).toBe(value)
+    }
+  })
+
+  test("still drops what the next sign-in must not inherit", () => {
+    const accountState = [
+      "onerep:offline-mutation-queue:v1",
+      "onerep:offline-owner:v1",
+      "onerep:coach-conversation:v1",
+      "onerep:active-workout-draft:v1:1",
+      "onerep:active-rest-timer:v1:1",
+      "onerep:retro-workout-draft:v1:1",
+      "onerep:active-endurance-workout:v1",
+      "onerep:aborted-workout-slot",
+      "onerep:fasting:active:v1",
+      "onerep:setup-preferences",
+      "onerep:onboarding-draft:v2",
+      "onerep:pending-verification-email",
+      "onerep:recent-food-searches:v1",
+      "onerep:celebrated:workout:2026-09-12",
+      "convex:auth",
+    ]
+    for (const key of accountState) localStorage.setItem(key, "value")
+
+    clearUnauthenticatedLocalState()
+
+    for (const key of accountState) {
+      expect(localStorage.getItem(key)).toBeNull()
+    }
   })
 
   test("marks intro as seen after unauthenticated cleanup", () => {

--- a/apps/mobile/src/lib/auth-session.ts
+++ b/apps/mobile/src/lib/auth-session.ts
@@ -18,7 +18,42 @@ const LOCAL_STORAGE_PREFIXES_TO_CLEAR = [
   "onerep-auth_",
   "better-auth_",
 ]
-const LOCAL_STORAGE_KEYS_TO_CLEAR = new Set(["theme"])
+/**
+ * Keys that describe *this phone* rather than the account that signed out.
+ *
+ * `onerep:` also holds account-shaped state — the offline mutation queue, the
+ * coach conversation, in-progress workout and fasting drafts, onboarding
+ * answers — and that must not survive a sign-out, because the next account on
+ * the same device would inherit it. Units, haptics, language, consent, and the
+ * layout the user has arranged are the opposite: they were chosen for the
+ * device, and a session that ends is no reason to make someone set them again.
+ *
+ * Add new device-level preferences here. Anything under a cleared prefix that
+ * is not listed is treated as account state and removed.
+ */
+const DEVICE_LOCAL_KEY_PREFIXES = [
+  "onerep:active-superset-tip-hidden",
+  "onerep:active-workout-simple-view",
+  "onerep:analytics-enabled",
+  "onerep:coach-model:",
+  "onerep:coach-onboarding-seen",
+  "onerep:energy-unit",
+  "onerep:haptics-",
+  "onerep:measurement-system",
+  "onerep:ota:",
+  "onerep:prelogin-onboarding-seen",
+  "onerep:preset-superset-tip-hidden",
+  "onerep:quick-add-fab-pos",
+  "onerep:quick-add-hint-seen",
+  "onerep:rest-bell-enabled",
+  "onerep:rest-vibration-enabled",
+  "onerep:server-override",
+  "onerep:ui-language",
+  "onerep:water-unit",
+  "onerep:weight-unit",
+  "theme",
+]
+
 const AUTH_REDIRECT_COOLDOWN_MS = 2_000
 const APP_ORIGIN_FOR_PATHS = "https://app.onerep.local"
 
@@ -41,13 +76,22 @@ export function isUnauthenticatedError(error: unknown) {
   return /\bUnauthenticated\b/i.test(text)
 }
 
+function isDeviceLocalKey(key: string) {
+  return DEVICE_LOCAL_KEY_PREFIXES.some((prefix) => key.startsWith(prefix))
+}
+
+/**
+ * Drops the account's cached state: auth tokens, the Convex cache, and the keys
+ * that hold what the previous account was doing. Device preferences survive —
+ * see DEVICE_LOCAL_KEY_PREFIXES.
+ */
 export function clearLocalStorageCache() {
   const storage = browserLocalStorage()
   if (!storage) return
 
   for (const key of safeStorageKeys(storage)) {
+    if (isDeviceLocalKey(key)) continue
     if (
-      LOCAL_STORAGE_KEYS_TO_CLEAR.has(key) ||
       LOCAL_STORAGE_PREFIXES_TO_CLEAR.some((prefix) => key.startsWith(prefix))
     ) {
       try {


### PR DESCRIPTION
A failed session currently takes the device's settings with it.

`handleUnauthenticatedSession` calls `clearUnauthenticatedLocalState`, which removes every key under `onerep:` — and that prefix is where both kinds of state live: the account's cached activity, and the preferences the user chose for this phone. So an expired session (or a session that fails to come back on a cold start) means the unit choices, haptics, language, the OTA bookkeeping, and even a self-hosted server override all reset, on top of the sign-out itself.

I hit this on an Android device: after a full WebView document load the app was signed out and `localStorage` had zero `onerep:` keys left, including `onerep:measurement-system` and the water unit.

## What changed

`clearLocalStorageCache` now skips an explicit list of device-local keys (`DEVICE_LOCAL_KEY_PREFIXES`) and clears everything else exactly as before.

**Kept** — these describe the phone, not the account: `theme`, the unit preferences (`measurement-system`, `weight-unit`, `energy-unit`, `water-unit` and its `-explicit` flag), haptics, rest bell/vibration, `ui-language`, `server-override`, `ota:*`, and the small UI affordances the user has arranged or dismissed (quick-add position/hint, superset tips, simple-view, the onboarding-seen flags).

**Still cleared** — anything that either identifies the account or holds what it was doing, so the next sign-in on a shared device cannot inherit it: the offline mutation queue and its owner key, the coach conversation, in-progress workout / rest-timer / retro / endurance drafts, the aborted-workout slot, a running fast, onboarding and setup answers, pending-verification state, and the recent search and celebration history. Analytics consent sits on this side of the line too — see below.

### Analytics consent is account state, not a device preference

`onerep:analytics-enabled` is the boot-time cache `main.tsx` reads to decide PostHog's state before any query lands, and it was on the device list in this PR's first revision. That was wrong, and the review was right to flag it: keeping it lets account A's choice opt account B into capture on the same phone, because nothing reconciled the key with the account that had just signed in. It is now cleared with the session, and `AnalyticsConsentSync` — a shell component next to `WidgetDataSync` — re-primes it from the account's own `privacySettings` once preferences arrive. In the shell rather than in Settings, so the choice comes back on launch instead of only when somebody opens the privacy section. An account whose `privacySettings` were never saved has no consent to carry, so a leftover key is removed rather than trusted.

The alternative was listing the account keys instead, but then a future preference added under `onerep:` would silently be wiped again, whereas an unlisted account key would leak. This way the default stays the safe one, and the file says where to add the next device preference.

Behavior is otherwise unchanged: the same sign-out and redirect still happen, on the same conditions and cooldown. This only narrows what the cleanup removes.

## Verification

- Tests cover the split directly, against the real key names in the tree: a device-preference set that must survive `clearUnauthenticatedLocalState()`, and an account-state set that must not — which now includes the consent key (`lib/__tests__/auth-session.test.ts`), plus assertions tying the sync component to that same key (`components/analytics-consent-sync.test.ts`).
- On the device (Android): seeding eleven device keys and six account keys and running the cleanup removed all six account keys, kept all eleven device keys, and left the live `onerep:water-unit` / `-explicit` values untouched.
- On the device, for this revision: with a stale `onerep:analytics-enabled=true` written into a signed-in session, a full WebView reload cleared it to `null` while `onerep:measurement-system`, `onerep:water-unit`, and `theme` survived. Seeding `false` behaves the same way. That is the exact sequence the review described.
- Full mobile suite: **1904 pass / 31 fail**, and the failing set is byte-identical to pristine `upstream/main` in this checkout (1900 pass / 31 fail — OTA rollout/activation, `app motion CSS`, haptics, offline-mutation toasts, responsive dashboard layout, retro/workout affordances; all pre-existing Windows line-ending failures). Typecheck clean.

One thing this does not change: the sign-out itself. A session that genuinely can't be restored still signs the user out — only the collateral damage is gone.

Two limits stated plainly: the "consent is on" branch was not exercised on the device, because doing so would mean flipping the real account's privacy setting; and PostHog is not configured in a local build, so only the cached key's behaviour was observable, not the capture client's.
