### PR TITLE
Keep analytics consent with the account, not the device

### DIFF
--- a/apps/mobile/src/components/analytics-consent-sync.test.ts
+++ b/apps/mobile/src/components/analytics-consent-sync.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+const COMPONENT = readFileSync(
+  new URL("./analytics-consent-sync.tsx", import.meta.url),
+  "utf8"
+)
+const AUTH_SESSION = readFileSync(
+  new URL("../lib/auth-session.ts", import.meta.url),
+  "utf8"
+)
+
+/**
+ * The consent cache is read in `main.tsx`, written by this component, and
+ * cleared by the sign-out path. Those three have to agree on the key and on
+ * the direction: it is account state, so a stale `true` must never outlive the
+ * session it belonged to.
+ */
+describe("analytics consent cache", () => {
+  test("re-primes the same key the boot path reads", () => {
+    expect(COMPONENT).toContain('"onerep:analytics-enabled"')
+    expect(COMPONENT).toContain("privacySettings?.analyticsEnabled")
+  })
+
+  test("puts PostHog in the account's state", () => {
+    expect(COMPONENT).toContain("posthog.opt_in_capturing()")
+    expect(COMPONENT).toContain("posthog.opt_out_capturing()")
+  })
+
+  test("waits for the account's answer before touching anything", () => {
+    expect(COMPONENT).toContain("if (!loaded) return")
+  })
+
+  test("treats an account with no saved consent as no consent", () => {
+    expect(COMPONENT).toContain("if (saved === true)")
+    expect(COMPONENT).toContain(
+      'safeLocalStorageRemove("onerep:analytics-enabled")'
+    )
+  })
+
+  test("is not treated as a device-local key on sign-out", () => {
+    const deviceLocalList = AUTH_SESSION.slice(
+      AUTH_SESSION.indexOf("const DEVICE_LOCAL_KEY_PREFIXES"),
+      AUTH_SESSION.indexOf("const AUTH_REDIRECT_COOLDOWN_MS")
+    )
+    expect(deviceLocalList).not.toContain("onerep:analytics-enabled")
+  })
+})

--- a/apps/mobile/src/components/analytics-consent-sync.tsx
+++ b/apps/mobile/src/components/analytics-consent-sync.tsx
@@ -1,0 +1,40 @@
+import { useEffect } from "react"
+import { useQuery } from "convex/react"
+import posthog from "posthog-js"
+import { api } from "../../../../convex/_generated/api"
+import { safeLocalStorageRemove, safeLocalStorageSet } from "@/lib/utils"
+
+/**
+ * Mirrors the account's saved analytics consent into the boot-time cache.
+ *
+ * `main.tsx` decides PostHog's state before any query lands, from the
+ * `onerep:analytics-enabled` local key. That key deliberately does *not*
+ * survive a sign-out — consent belongs to the account, not the phone, and a
+ * leftover `true` would capture whichever account signs in next — so every
+ * session has to hand it back once the account's `privacySettings` arrive.
+ * This mounts in the app shell rather than in Settings, because the choice has
+ * to be restored on launch, not only when someone opens the privacy section.
+ *
+ * The loaded-but-unset case is the one that matters: an account that never
+ * saved the Privacy section has no `privacySettings` at all, and that is not
+ * consent. It clears whatever the previous account left behind instead of
+ * trusting it.
+ */
+export function AnalyticsConsentSync() {
+  const preferences = useQuery(api.users.users.getPreferences, {})
+  const loaded = preferences !== undefined
+  const saved = preferences?.privacySettings?.analyticsEnabled
+
+  useEffect(() => {
+    if (!loaded) return
+    if (saved === true) {
+      safeLocalStorageSet("onerep:analytics-enabled", "true")
+      posthog.opt_in_capturing()
+      return
+    }
+    safeLocalStorageRemove("onerep:analytics-enabled")
+    posthog.opt_out_capturing()
+  }, [loaded, saved])
+
+  return null
+}

--- a/apps/mobile/src/lib/__tests__/auth-session.test.ts
+++ b/apps/mobile/src/lib/__tests__/auth-session.test.ts
@@ -98,7 +98,6 @@ describe("auth session helpers", () => {
       ["onerep:rest-bell-enabled", "true"],
       ["onerep:rest-vibration-enabled", "true"],
       ["onerep:ui-language", "en"],
-      ["onerep:analytics-enabled", "true"],
       ["onerep:server-override", "{}"],
       ["onerep:ota:pending-bundle", "{}"],
       ["onerep:quick-add-hint-seen", "1"],
@@ -131,6 +130,9 @@ describe("auth session helpers", () => {
       "onerep:pending-verification-email",
       "onerep:recent-food-searches:v1",
       "onerep:celebrated:workout:2026-09-12",
+      // Consent is about the account, not the phone: keeping this would let the
+      // first account's choice opt the next one into capture.
+      "onerep:analytics-enabled",
       "convex:auth",
     ]
     for (const key of accountState) localStorage.setItem(key, "value")

--- a/apps/mobile/src/lib/auth-session.ts
+++ b/apps/mobile/src/lib/auth-session.ts
@@ -24,9 +24,18 @@ const LOCAL_STORAGE_PREFIXES_TO_CLEAR = [
  * `onerep:` also holds account-shaped state — the offline mutation queue, the
  * coach conversation, in-progress workout and fasting drafts, onboarding
  * answers — and that must not survive a sign-out, because the next account on
- * the same device would inherit it. Units, haptics, language, consent, and the
- * layout the user has arranged are the opposite: they were chosen for the
- * device, and a session that ends is no reason to make someone set them again.
+ * the same device would inherit it. Units, haptics, language, and the layout
+ * the user has arranged are the opposite: they were chosen for the device, and
+ * a session that ends is no reason to make someone set them again.
+ *
+ * Analytics consent is the exception that proves the rule: it is a preference
+ * *about the account*, not about the phone, because it decides whether the next
+ * account to sign in here gets captured. It lives in the account's
+ * `privacySettings`, with `onerep:analytics-enabled` as the boot-time cache
+ * `main.tsx` reads before any query lands. That cache is deliberately absent
+ * from the list below so it dies with the session it was cached for; the
+ * `AnalyticsConsentSync` shell component re-primes it from the account's saved
+ * value on the next launch.
  *
  * Add new device-level preferences here. Anything under a cleared prefix that
  * is not listed is treated as account state and removed.
@@ -34,7 +43,6 @@ const LOCAL_STORAGE_PREFIXES_TO_CLEAR = [
 const DEVICE_LOCAL_KEY_PREFIXES = [
   "onerep:active-superset-tip-hidden",
   "onerep:active-workout-simple-view",
-  "onerep:analytics-enabled",
   "onerep:coach-model:",
   "onerep:coach-onboarding-seen",
   "onerep:energy-unit",

--- a/apps/mobile/src/main.tsx
+++ b/apps/mobile/src/main.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/lib/auth-session"
 import { WidgetDataSync } from "@/components/widget-data-sync"
 import { HealthSync } from "@/components/health-sync"
+import { AnalyticsConsentSync } from "@/components/analytics-consent-sync"
 import { CoachPushRegistration } from "@/components/coach-push-registration"
 import { MealCategorySync } from "@/components/meal-category-sync"
 import { RetentionTracking } from "@/components/retention-tracking"
@@ -1372,6 +1373,7 @@ createRoot(document.getElementById("root")!).render(
             <OfflineSyncIndicator />
             <WidgetDataSync />
             <HealthSync />
+            <AnalyticsConsentSync />
             <CoachPushRegistration />
             <MealCategorySync />
             <RetentionTracking />


### PR DESCRIPTION
Follow-up to #77, which is merged and whose review thread flagged this.

## The problem

`onerep:analytics-enabled` was on the device-local list, but it is not a device preference. `main.tsx` decides PostHog's state from that key *before any query lands*:

```ts
if (localStorage.getItem("onerep:analytics-enabled") === "true") {
  posthog.opt_in_capturing()
} else {
  posthog.opt_out_capturing()
}
```

So carrying it across a sign-out lets account A's choice opt account B into capture on the same phone. Nothing reconciled it either: the signed-in account's `privacySettings` reached React state inside Settings (`Settings.tsx`, hydration) and never the key or the client.

## The fix

- The key comes off `DEVICE_LOCAL_KEY_PREFIXES`, so it is cleared with the session like the rest of the account's state. The file's comment now says why, so it does not get re-added by the next person diffing this list.
- `components/analytics-consent-sync.tsx` mounts in the app shell next to `WidgetDataSync` and re-primes the cache from the account's saved `privacySettings` — writing the key *and* calling `opt_in_capturing()` / `opt_out_capturing()`, so the client and the cache agree. In the shell rather than in Settings, so the choice comes back on launch instead of only when someone opens the privacy section.
- The loaded-but-unset case is treated as refusal rather than as "keep whatever was there": an account with no saved `privacySettings` clears the key and stays opted out. Without this, a leftover `true` would still be trusted on exactly the account that never consented — the case the review described.

Everything else about #77 is unchanged: the sign-out and redirect still happen on the same conditions, and the account-shaped keys (offline queue and owner, coach conversation, in-progress drafts, onboarding answers, recent-search and celebration history) are still cleared.

## Verification

- On the device (Android, release build of this branch): with a stale `onerep:analytics-enabled=true` seeded into a signed-in session, a full WebView reload cleared it to `null` while `onerep:measurement-system`, `onerep:water-unit`, and `theme` survived. Seeding `false` behaves identically. That is the exact sequence from the review.
- Tests: `lib/__tests__/auth-session.test.ts` now asserts the consent key is in the cleared set, and `components/analytics-consent-sync.test.ts` asserts the component writes the same key the sign-out path clears, waits for the account's answer, and treats an unset value as refusal.
- Full mobile suite: **1905 pass / 31 fail**, with a failing set identical to pristine `upstream/main` in this checkout (OTA rollout/activation, `app motion CSS`, haptics, offline-mutation toasts, responsive dashboard layout, retro/workout affordances — all pre-existing Windows line-ending failures). `tsc -b` clean.

## Not verified

Two things rest on the code path and the tests rather than on observation, and I would rather say so than imply otherwise:

- The consent-**on** branch was not exercised on the device, because doing so would mean flipping the real account's privacy setting.
- PostHog is not configured in a local build, so only the cached key's behaviour was observable, not the capture client's. The calls are the same shape as the ones already in `main.tsx` and `handleSavePrivacy`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analytics tracking now reflects each signed-in account’s saved consent settings.
  * Analytics remains disabled when consent is unavailable or not granted.
  * Consent settings are cleared during sign-out to prevent them carrying over to another account.

* **Tests**
  * Added coverage for consent synchronization, analytics tracking states, and sign-out behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->